### PR TITLE
QuCoeffs: A more controlled approach to QuArray coefficient containers

### DIFF
--- a/src/QuBase.jl
+++ b/src/QuBase.jl
@@ -54,7 +54,7 @@ module QuBase
     # Include Statements #
     ######################
         include("bases/bases.jl")
-        include("arrays/quarray.jl")
+        include("arrays/arrays.jl")
     
     export AbstractStructure, 
         AbstractQuantum,

--- a/src/arrays/arrays.jl
+++ b/src/arrays/arrays.jl
@@ -1,0 +1,8 @@
+######################
+# Include Statements #
+######################
+    include("qucoeffs.jl")
+    include("quarray.jl")
+    include("constructors.jl")
+    include("ladderops.jl")
+    

--- a/src/arrays/constructors.jl
+++ b/src/arrays/constructors.jl
@@ -1,0 +1,13 @@
+import Base: zeros,
+    eye,
+
+############################
+# Convenience Constructors #
+############################
+    statevec(i::Int, fb::FiniteBasis) = QuArray(single_coeff(i, length(fb)), fb)
+    statevec(i::Int, lens::Int...=i) = statevec(i, FiniteBasis(lens))
+
+    zeros(qa::AbstractQuArray) = QuArray(zeros(coeffs(qa)), bases(qa))
+    eye(qa::AbstractQuArray) = QuArray(eye(coeffs(qa)), bases(qa))
+
+export statevec

--- a/src/arrays/constructors.jl
+++ b/src/arrays/constructors.jl
@@ -7,7 +7,16 @@ import Base: zeros,
     statevec(i::Int, fb::FiniteBasis) = QuArray(single_coeff(i, length(fb)), fb)
     statevec(i::Int, lens::Int...=i) = statevec(i, FiniteBasis(lens))
 
+    ###########################
+    # Array-like Constructors #
+    ###########################
     zeros(qa::AbstractQuArray) = QuArray(zeros(coeffs(qa)), bases(qa))
     eye(qa::AbstractQuArray) = QuArray(eye(coeffs(qa)), bases(qa))
+
+    ####################
+    # Helper Functions #
+    ####################
+    one_at_ind!(arr, i) = setindex!(arr, one(eltype(arr)), i)
+    single_coeff(i, lens...) = one_at_ind!(zeros(lens), i)
 
 export statevec

--- a/src/arrays/constructors.jl
+++ b/src/arrays/constructors.jl
@@ -1,5 +1,5 @@
 import Base: zeros,
-    eye,
+    eye
 
 ############################
 # Convenience Constructors #

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -13,8 +13,6 @@ import Base: size,
     -,.-,
     kron
 
-include("qucoeffs.jl")
-
 abstract AbstractQuArray{B<:AbstractBasis,T,N}
 
 typealias AbstractQuVector{B<:AbstractBasis,T} AbstractQuArray{B,T,1}
@@ -72,12 +70,6 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
                "...coeff: $A"             
     end
 
-    ######################
-    # Include Statements #
-    ######################
-    include("constructors.jl")
-    include("ladderops.jl")
-    
     ####################
     # Helper Functions #
     ####################

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -33,11 +33,11 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
         end
     end
     
-    typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,CoeffsVector{false,false,T,A}}
-    typealias QuCoVector{B<:AbstractBasis,T,A} QuArray{B,T,1,AdjVector{T,A}}
+    typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,A}
+    typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,A}
 
-    typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,CoeffsMatrix{false,false,T,A}}
-    typealias QuAdjMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,AdjMatrix{T,A}}
+    typealias QuKet{B<:AbstractBasis,T,A} QuArray{B,T,1,KetCoeffs{T,A}}
+    typealias QuBra{B<:AbstractBasis,T,A} QuArray{B,T,1,BraCoeffs{T,A}}
 
     QuArray{Conj,Tran,T,N,B<:AbstractBasis}(coeffs::QuCoeffs{Conj,Tran,T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
     QuArray{N,B<:AbstractBasis}(coeffs::AbstractArray, bases::NTuple{N,B}) = QuArray(QuCoeffs(coeffs), bases)
@@ -55,7 +55,7 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     ########################
     size(qa::AbstractQuArray, i...) = size(coeffs(qa), i...)
     length(qa::AbstractQuArray) = length(coeffs(qa))
-    
+
     getindex(qa::AbstractQuArray, i) = getindex(coeffs(qa), i)
     getindex(qa::AbstractQuArray, i...) = getindex(coeffs(qa), i...)
 

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -54,7 +54,8 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     # Array-like functions #
     ########################
     size(qa::AbstractQuArray, i...) = size(coeffs(qa), i...)
-
+    length(qa::AbstractQuArray) = length(coeffs(qa))
+    
     getindex(qa::AbstractQuArray, i) = getindex(coeffs(qa), i)
     getindex(qa::AbstractQuArray, i...) = getindex(coeffs(qa), i...)
 

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -1,11 +1,11 @@
 import Base: size,
     length,
     getindex,
-    similar,
     in,
-    ctranspose,
-    transpose,
     summary,
+    transpose,
+    ctranspose,
+    conj,
     #TODO: Implement the below operations
     *,.*,
     /,./,
@@ -13,7 +13,9 @@ import Base: size,
     -,.-,
     kron
 
-abstract AbstractQuArray{B<:AbstractBasis,T,N} <: AbstractArray{T,N}
+include("qucoeffs.jl")
+
+abstract AbstractQuArray{B<:AbstractBasis,T,N}
 
 typealias AbstractQuVector{B<:AbstractBasis,T} AbstractQuArray{B,T,1}
 typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
@@ -21,13 +23,10 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
 ###########
 # QuArray #                 
 ###########
-    # Using an NTuple allows us to have a basis for each dimension, 
-    # and gives us a less ambiguous way to determine if a QuArray will act
-    # like a vector, matrix, or tensor using the dimension parameter N. 
     type QuArray{B<:AbstractBasis,T,N,A} <: AbstractQuArray{B,T,N}
         coeffs::A
         bases::NTuple{N,B}
-        function QuArray(coeffs::AbstractArray{T}, bases::NTuple{N,B}) 
+        function QuArray(coeffs::AbstractQuCoeffs{T,N}, bases::NTuple{N,B}) 
             if checkbases(coeffs, bases) 
                 new(coeffs, bases)
             else 
@@ -38,8 +37,9 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     
     typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,A}
     typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,A}
-
-    QuArray{T,N,B<:AbstractBasis}(coeffs::AbstractArray{T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
+    
+    QuArray{T,N,B<:AbstractBasis}(coeffs::AbstractQuCoeffs{T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
+    QuArray{N,B<:AbstractBasis}(coeffs::AbstractArray, bases::NTuple{N,B}) = QuArray(QuCoeffs(coeffs), bases)
     QuArray(coeffs, bases::AbstractBasis...) = QuArray(coeffs, bases)
     QuArray(coeffs) = QuArray(coeffs, basesfordims(size(coeffs)))
     
@@ -48,32 +48,20 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     ######################
     bases(qa::QuArray) = qa.bases
     coeffs(qa::QuArray) = qa.coeffs
-    size(qa::QuArray, i...) = size(qa.coeffs, i...)
 
     ########################
     # Array-like functions #
     ########################
-    similar{B,T}(qa::QuArray{B,T}, element_type=T) = QuArray(similar(qa.coeffs, T), qa.bases)
-    # Is there a way to properly define the below for
-    # any arbitrary basis? Obviously doesn't make sense
-    # for B<:AbstractInfiniteBasis, and I'm reluctant to
-    # enforce that every B<:AbstractFiniteBasis will have a 
-    # constructor B(::Int), which is how the below is constructing
-    # instances of FiniteBasis.
-    function similar{B<:FiniteBasis,T}(qa::QuArray{B,T}, element_type, dims)
-        return QuArray(similar(qa.coeffs, T, dims), basesfordims(dims, B))
-    end 
-    getindex(qa::QuArray, i::AbstractArray) = getindex(qa.coeffs, i)
-    getindex(qa::QuArray, i::Real) = getindex(qa.coeffs, i)
-    getindex(qa::QuArray, i) = getindex(qa.coeffs, i)
-    getindex(qa::QuArray, i...) = getindex(qa.coeffs, i...)
+    size(qa::AbstractQuArray, i...) = size(coeffs(qa), i...)
 
-    in(c, qa::QuArray) = in(c, qa.coeffs)
+    getindex(qa::AbstractQuArray, i) = getindex(coeffs(qa), i)
+    getindex(qa::AbstractQuArray, i...) = getindex(coeffs(qa), i...)
 
-    ctranspose(qa::QuVector) = QuArray(ctranspose(qa.coeffs), qa.bases)
-    ctranspose(qa::QuMatrix) = QuArray(ctranspose(qa.coeffs), reverse(qa.bases))
-    transpose(qa::QuVector) = QuArray(transpose(qa.coeffs), qa.bases)
-    transpose(qa::QuMatrix) = QuArray(transpose(qa.coeffs), reverse(qa.bases))
+    in(c, qa::AbstractQuArray) = in(c, coeffs(qa))
+
+    conj(qa::AbstractQuArray) = QuArray(conj(coeffs(qa)), bases(qa))
+    transpose(qa::AbstractQuArray) = QuArray(transpose(coeffs(qa)), reverse(bases(qa)))
+    ctranspose(qa::AbstractQuArray) = QuArray(ctranspose(coeffs(qa)), reverse(bases(qa)))
 
     ######################
     # Printing Functions #
@@ -96,20 +84,6 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     sizenotation(tup::(Int,)) = "$(first(tup))-element"
     sizenotation(tup::(Int...)) = reduce(*, map(s->"$(s)x", tup))[1:end-1] 
 
-    # checkbases() is overloaded for a single basis
-    # to handle the fact that row vectors are
-    # N=2
-    function checkbases(coeffs, bases::NTuple{1, AbstractBasis})
-        if ndims(coeffs) <= 2
-            if size(coeffs, 2) == 1
-                return checkcoeffs(coeffs, 1, first(bases))
-            elseif size(coeffs, 1) == 1
-                return checkcoeffs(coeffs, 2, first(bases))
-            end 
-        end
-        return false
-    end
-
     function checkbases{N}(coeffs, bases::NTuple{N, AbstractBasis})
         if ndims(coeffs) == length(bases)
             return reduce(&, [checkcoeffs(coeffs, i, bases[i]) for i=1:N])
@@ -122,8 +96,6 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     function basesfordims(lens::Tuple, B=ntuple(length(lens), x->FiniteBasis))
         return ntuple(length(lens), n->B[n](lens[n]))
     end
-    one_at_ind!(arr, i) = setindex!(arr, one(eltype(arr)), i)
-    single_coeff(i, lens...) = one_at_ind!(zeros(lens), i)
 
 export AbstractQuArray,
     QuArray,

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -24,7 +24,7 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     type QuArray{B<:AbstractBasis,T,N,A} <: AbstractQuArray{B,T,N}
         coeffs::A
         bases::NTuple{N,B}
-        function QuArray(coeffs::AbstractQuCoeffs{T,N}, bases::NTuple{N,B}) 
+        function QuArray{Conj,Tran}(coeffs::QuCoeffs{Conj,Tran,T,N}, bases::NTuple{N,B}) 
             if checkbases(coeffs, bases) 
                 new(coeffs, bases)
             else 
@@ -33,10 +33,13 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
         end
     end
     
-    typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,A}
-    typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,A}
-    
-    QuArray{T,N,B<:AbstractBasis}(coeffs::AbstractQuCoeffs{T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
+    typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,CoeffsVector{false,false,T,A}}
+    typealias QuCoVector{B<:AbstractBasis,T,A} QuArray{B,T,1,AdjVector{T,A}}
+
+    typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,CoeffsMatrix{false,false,T,A}}
+    typealias QuAdjMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,AdjMatrix{T,A}}
+
+    QuArray{Conj,Tran,T,N,B<:AbstractBasis}(coeffs::QuCoeffs{Conj,Tran,T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
     QuArray{N,B<:AbstractBasis}(coeffs::AbstractArray, bases::NTuple{N,B}) = QuArray(QuCoeffs(coeffs), bases)
     QuArray(coeffs, bases::AbstractBasis...) = QuArray(coeffs, bases)
     QuArray(coeffs) = QuArray(coeffs, basesfordims(size(coeffs)))

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -21,7 +21,7 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
 ###########
 # QuArray #
 ###########
-    type QuArray{B<:AbstractBasis,T,N,C<:QuCoeffs} <: AbstractQuArray{B,T,N}
+    type QuArray{B<:AbstractBasis,T,N,C} <: AbstractQuArray{B,T,N}
         coeffs::C
         bases::NTuple{N,B}
         function QuArray{D}(coeffs::QuCoeffs{D,T,N}, bases::NTuple{N,B}) 

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -36,8 +36,8 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,A}
     typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,A}
 
-    typealias QuKet{B<:AbstractBasis,T,A} QuArray{B,T,1,KetCoeffs{T,A}}
-    typealias QuBra{B<:AbstractBasis,T,A} QuArray{B,T,1,BraCoeffs{T,A}}
+    typealias QuKet{B<:AbstractBasis,T,KC<:KetCoeffs} QuArray{B,T,1,KC}
+    typealias QuBra{B<:AbstractBasis,T,BC<:BraCoeffs} QuArray{B,T,1,BC}
 
     QuArray{Conj,Tran,T,N,B<:AbstractBasis}(coeffs::QuCoeffs{Conj,Tran,T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
     QuArray{N,B<:AbstractBasis}(coeffs::AbstractArray, bases::NTuple{N,B}) = QuArray(QuCoeffs(coeffs), bases)

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -6,8 +6,6 @@ import Base: size,
     ctranspose,
     transpose,
     summary,
-    zeros,
-    eye,
     #TODO: Implement the below operations
     *,.*,
     /,./,
@@ -45,15 +43,6 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     QuArray(coeffs, bases::AbstractBasis...) = QuArray(coeffs, bases)
     QuArray(coeffs) = QuArray(coeffs, basesfordims(size(coeffs)))
     
-    ############################
-    # Convenience Constructors #
-    ############################
-    statevec(i::Int, fb::FiniteBasis) = QuArray(single_coeff(i, length(fb)), fb)
-    statevec(i::Int, lens::Int...=i) = statevec(i, FiniteBasis(lens))
-    
-    zeros(qa::QuArray) = QuArray(zeros(qa.coeffs), qa.bases)
-    eye(qa::QuArray) = QuArray(eye(qa.coeffs), qa.bases)
-
     ######################
     # Property Functions #
     ######################
@@ -98,6 +87,7 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     ######################
     # Include Statements #
     ######################
+    include("constructors.jl")
     include("ladderops.jl")
     
     ####################
@@ -140,5 +130,4 @@ export AbstractQuArray,
     QuVector,
     QuMatrix,
     bases,
-    coeffs,
-    statevec
+    coeffs

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -19,12 +19,12 @@ typealias AbstractQuVector{B<:AbstractBasis,T} AbstractQuArray{B,T,1}
 typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
 
 ###########
-# QuArray #                 
+# QuArray #
 ###########
-    type QuArray{B<:AbstractBasis,T,N,A} <: AbstractQuArray{B,T,N}
-        coeffs::A
+    type QuArray{B<:AbstractBasis,T,N,C<:QuCoeffs} <: AbstractQuArray{B,T,N}
+        coeffs::C
         bases::NTuple{N,B}
-        function QuArray{Conj,Tran}(coeffs::QuCoeffs{Conj,Tran,T,N}, bases::NTuple{N,B}) 
+        function QuArray{D}(coeffs::QuCoeffs{D,T,N}, bases::NTuple{N,B}) 
             if checkbases(coeffs, bases) 
                 new(coeffs, bases)
             else 
@@ -36,10 +36,10 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     typealias QuVector{B<:AbstractBasis,T,A} QuArray{B,T,1,A}
     typealias QuMatrix{B<:AbstractBasis,T,A} QuArray{B,T,2,A}
 
-    typealias QuKet{B<:AbstractBasis,T,KC<:KetCoeffs} QuArray{B,T,1,KC}
-    typealias QuBra{B<:AbstractBasis,T,BC<:BraCoeffs} QuArray{B,T,1,BC}
+    typealias QuKet{B<:AbstractBasis,T,KC<:KetCoeffs} QuVector{B,T,KC}
+    typealias QuBra{B<:AbstractBasis,T,BC<:BraCoeffs} QuVector{B,T,BC}
 
-    QuArray{Conj,Tran,T,N,B<:AbstractBasis}(coeffs::QuCoeffs{Conj,Tran,T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
+    QuArray{D,T,N,B<:AbstractBasis}(coeffs::QuCoeffs{D,T}, bases::NTuple{N,B}) = QuArray{B,T,N,typeof(coeffs)}(coeffs, bases)
     QuArray{N,B<:AbstractBasis}(coeffs::AbstractArray, bases::NTuple{N,B}) = QuArray(QuCoeffs(coeffs), bases)
     QuArray(coeffs, bases::AbstractBasis...) = QuArray(coeffs, bases)
     QuArray(coeffs) = QuArray(coeffs, basesfordims(size(coeffs)))
@@ -54,16 +54,21 @@ typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
     # Array-like functions #
     ########################
     size(qa::AbstractQuArray, i...) = size(coeffs(qa), i...)
+    ndims(qa::AbstractQuArray) = ndims(coeffs(qa))
     length(qa::AbstractQuArray) = length(coeffs(qa))
 
     getindex(qa::AbstractQuArray, i) = getindex(coeffs(qa), i)
     getindex(qa::AbstractQuArray, i...) = getindex(coeffs(qa), i...)
+
+    setindex!(qa::AbstractQuArray, i) = setindex!(coeffs(qa), i)
+    setindex!(qa::AbstractQuArray, i...) = setindex!(coeffs(qa), i...)
 
     in(c, qa::AbstractQuArray) = in(c, coeffs(qa))
 
     conj(qa::AbstractQuArray) = QuArray(conj(coeffs(qa)), bases(qa))
     transpose(qa::AbstractQuArray) = QuArray(transpose(coeffs(qa)), reverse(bases(qa)))
     ctranspose(qa::AbstractQuArray) = QuArray(ctranspose(coeffs(qa)), reverse(bases(qa)))
+    dual(qa::AbstractQuArray) = QuArray(dual(coeffs(qa)), reverse(bases(qa)))
 
     ######################
     # Printing Functions #
@@ -97,5 +102,6 @@ export AbstractQuArray,
     QuArray,
     QuVector,
     QuMatrix,
+    dual,
     bases,
     coeffs

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -17,6 +17,9 @@ import Base: size,
 
 abstract AbstractQuArray{B<:AbstractBasis,T,N} <: AbstractArray{T,N}
 
+typealias AbstractQuVector{B<:AbstractBasis,T} AbstractQuArray{B,T,1}
+typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
+
 ###########
 # QuArray #                 
 ###########

--- a/src/arrays/qucoeffs.jl
+++ b/src/arrays/qucoeffs.jl
@@ -1,0 +1,64 @@
+import Base: transpose,
+    ctranspose,
+    size,
+    ndims,
+    length,
+    getindex
+
+############
+# QuCoeffs #                 
+############
+    abstract AbstractQuCoeffs{T,N,A}
+    abstract ConjBool{Conj}
+    abstract TranBool{Tran}
+
+    type QuCoeffs{Conj,Tran,T,N,A} <: AbstractQuCoeffs{T,N,A}
+        arr::A  
+        conj::Type{ConjBool{Conj}}
+        tran::Type{TranBool{Tran}}
+    end
+
+    function QuCoeffs{T,N,Conj,Tran}(arr::AbstractArray{T,N}, 
+                                     conj::Type{ConjBool{Conj}}, 
+                                     tran::Type{TranBool{Tran}})
+        return QuCoeffs{Conj,Tran,T,N,typeof(arr)}(arr, conj, tran)
+    end
+
+    QuCoeffs(arr) = QuCoeffs(arr, ConjBool{false}, TranBool{false})
+    
+    typealias CoeffsVector{Conj,Tran,T,A} QuCoeffs{Conj,Tran,T,1,A}
+    typealias CoeffsMatrix{Conj,Tran,T,A} QuCoeffs{Conj,Tran,T,2,A}
+
+    typealias ConjVector{Tran,T,A} CoeffsVector{true,Tran,T,A}
+    typealias ConjMatrix{Tran,T,A} CoeffsMatrix{true,Tran,T,A}
+
+    typealias TranVector{Conj,T,A} CoeffsVector{Conj,true,T,A}
+    typealias TranMatrix{Conj,T,A} CoeffsMatrix{Conj,true,T,A}
+
+    typealias AdjVector{T,A} CoeffsVector{true,true,T,A}
+    typealias AdjMatrix{T,A} CoeffsMatrix{true,true,T,A}
+
+    ########################
+    # Array-like Functions #
+    ########################
+    size(qc::QuCoeffs) = size(qc.arr)
+    size(qc::QuCoeffs, i...) = size(qc.arr, i...)
+    size(tm::TranMatrix) = reverse(size(tm.arr))
+    size(tm::TranMatrix, i) = size(tm)[i]
+    ndims(qc::QuCoeffs) = length(size(qc))
+    length(qc::QuCoeffs) = prod(size(qc))
+
+    apply_conj(i::Complex, ::Type{ConjBool{true}}) = conj(i)
+    apply_conj(i, conj) = i
+
+    getindex(cv::CoeffsVector, i) = apply_conj(cv.arr[i], cv.conj)
+    getindex(cv::CoeffsMatrix, i, j) = apply_conj(cv.arr[i,j], cv.conj)
+    getindex(cv::TranMatrix, i, j) = apply_conj(cv.arr[j,i], cv.conj)
+
+    #######################
+    # Conjugate/Transpose #                 
+    #######################
+    conj{Conj,Tran}(qc::QuCoeffs{Conj,Tran}) = QuCoeffs(qc.arr, ConjBool{!(Conj)}, TranBool{Tran})
+    transpose{Conj,Tran}(qc::QuCoeffs{Conj,Tran}) = QuCoeffs(qc.arr, ConjBool{Conj}, TranBool{!(Tran)})
+    ctranspose{Conj,Tran}(qc::QuCoeffs{Conj,Tran}) = QuCoeffs(qc.arr, ConjBool{!(Conj)}, TranBool{!(Tran)})
+

--- a/src/arrays/qucoeffs.jl
+++ b/src/arrays/qucoeffs.jl
@@ -10,11 +10,10 @@ import Base: transpose,
 ############
 # QuCoeffs #                 
 ############
-    abstract AbstractQuCoeffs{T,N,A}
     abstract ConjBool{Conj}
     abstract TranBool{Tran}
 
-    type QuCoeffs{Conj,Tran,T,N,A} <: AbstractQuCoeffs{T,N,A}
+    type QuCoeffs{Conj,Tran,T,N,A}
         arr::A  
         conj::Type{ConjBool{Conj}}
         tran::Type{TranBool{Tran}}

--- a/src/arrays/qucoeffs.jl
+++ b/src/arrays/qucoeffs.jl
@@ -3,7 +3,8 @@ import Base: transpose,
     size,
     ndims,
     length,
-    getindex
+    getindex,
+    setindex!
 
 ############
 # QuCoeffs #                 
@@ -49,11 +50,16 @@ import Base: transpose,
     length(qc::QuCoeffs) = prod(size(qc))
 
     apply_conj(i::Complex, ::Type{ConjBool{true}}) = conj(i)
+    apply_conj(i::Complex, qc::QuCoeffs) = apply_conj(i, qc.conj)
     apply_conj(i, conj) = i
 
-    getindex(cv::CoeffsVector, i) = apply_conj(cv.arr[i], cv.conj)
-    getindex(cv::CoeffsMatrix, i, j) = apply_conj(cv.arr[i,j], cv.conj)
-    getindex(cv::TranMatrix, i, j) = apply_conj(cv.arr[j,i], cv.conj)
+    getindex(cv::CoeffsVector, i) = apply_conj(cv.arr[i], cv)
+    getindex(cv::CoeffsMatrix, i, j) = apply_conj(cv.arr[i,j], cv)
+    getindex(cv::TranMatrix, i, j) = apply_conj(cv.arr[j,i], cv)
+
+    setindex!(cv::CoeffsVector, x, y) = setindex!(cv, apply_conj(x, cv), y)
+    setindex!(cv::CoeffsMatrix, x, y, z) = setindex!(cv, apply_conj(x, cv), y, z)
+    setindex!(cv::TranMatrix,  x, y, z) = setindex!(cv, apply_conj(x, cv), z, y)
 
     #######################
     # Conjugate/Transpose #                 
@@ -61,4 +67,3 @@ import Base: transpose,
     conj{Conj,Tran}(qc::QuCoeffs{Conj,Tran}) = QuCoeffs(qc.arr, ConjBool{!(Conj)}, TranBool{Tran})
     transpose{Conj,Tran}(qc::QuCoeffs{Conj,Tran}) = QuCoeffs(qc.arr, ConjBool{Conj}, TranBool{!(Tran)})
     ctranspose{Conj,Tran}(qc::QuCoeffs{Conj,Tran}) = QuCoeffs(qc.arr, ConjBool{!(Conj)}, TranBool{!(Tran)})
-

--- a/src/arrays/qucoeffs.jl
+++ b/src/arrays/qucoeffs.jl
@@ -1,5 +1,6 @@
 import Base: transpose,
     ctranspose,
+    conj,
     size,
     ndims,
     length,

--- a/src/arrays/qucoeffs.jl
+++ b/src/arrays/qucoeffs.jl
@@ -30,15 +30,17 @@ import Base: transpose,
     typealias CoeffsVector{Conj,Tran,T,A} QuCoeffs{Conj,Tran,T,1,A}
     typealias CoeffsMatrix{Conj,Tran,T,A} QuCoeffs{Conj,Tran,T,2,A}
 
-    typealias ConjVector{Tran,T,A} CoeffsVector{true,Tran,T,A}
-    typealias ConjMatrix{Tran,T,A} CoeffsMatrix{true,Tran,T,A}
+    typealias KetCoeffs{T,A} CoeffsVector{false,false,T,A}
+    typealias BraCoeffs{T,A} CoeffsVector{true,true,T,A}
 
-    typealias TranVector{Conj,T,A} CoeffsVector{Conj,true,T,A}
-    typealias TranMatrix{Conj,T,A} CoeffsMatrix{Conj,true,T,A}
+    typealias TranCoeffs{Conj,T,N,A} QuCoeffs{Conj,true,T,N,A}
+    typealias TranVector{Conj,T,A} TranCoeffs{Conj,T,1,A}
+    typealias TranMatrix{Conj,T,A} TranCoeffs{Conj,T,2,A}
 
-    typealias AdjVector{T,A} CoeffsVector{true,true,T,A}
-    typealias AdjMatrix{T,A} CoeffsMatrix{true,true,T,A}
-
+    typealias ConjCoeffs{Tran,T,N,A} QuCoeffs{true,Tran,T,N,A}
+    typealias ConjVector{Tran,T,A} ConjCoeffs{Tran,T,1,A}
+    typealias ConjMatrix{Tran,T,A} ConjCoeffs{Tran,T,2,A}
+    
     ########################
     # Array-like Functions #
     ########################

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -33,7 +33,7 @@
     # structure{S}(::Type{MyBasisType{S}}) -> returns S<:AbstractStructure for 
     #                                         the provided basis type.
 
-    checkcoeffs(coeffs, dim::Int, basis::AbstractBasis) = error("checkcoeffs(coeffs, dim, ::$B) must be defined!")
+    checkcoeffs(coeffs, dim, basis::AbstractBasis) = error("checkcoeffs(coeffs, dim, ::$(typeof(basis))) must be defined!")
 
     for basis=(:AbstractBasis, :AbstractFiniteBasis, :AbstractInfiniteBasis)
         @eval begin

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -33,7 +33,7 @@
     # structure{S}(::Type{MyBasisType{S}}) -> returns S<:AbstractStructure for 
     #                                         the provided basis type.
 
-    checkcoeffs(coeffs::AbstractArray, dim::Int, basis::AbstractBasis) = error("checkcoeffs(coeffs, dim, ::$B) must be defined!")
+    checkcoeffs(coeffs, dim::Int, basis::AbstractBasis) = error("checkcoeffs(coeffs, dim, ::$B) must be defined!")
 
     for basis=(:AbstractBasis, :AbstractFiniteBasis, :AbstractInfiniteBasis)
         @eval begin

--- a/src/bases/finitebasis.jl
+++ b/src/bases/finitebasis.jl
@@ -45,7 +45,7 @@ import Base: convert,
     size(basis::FiniteBasis) = basis.lens
     size(basis::FiniteBasis, i) = basis.lens[i]
     nfactors{S,N}(::FiniteBasis{S,N}) = N
-    checkcoeffs(coeffs::AbstractArray, dim::Int, basis::FiniteBasis) = size(coeffs, dim) == length(basis) 
+    checkcoeffs(coeffs, dim::Int, basis::FiniteBasis) = size(coeffs, dim) == length(basis) 
 
     ##########################
     # Mathematical Functions #


### PR DESCRIPTION
This PR presents a new wrapper type, `QuCoeffs`, which gives us better control over the behavior of QuArrays' coefficient containers.

Specifically, this is an attempt at providing a solution to #9. 

Major changes:
1. The `QuCoeffs` type. This type provides a wrapper for lazy conjugation/transposition on arbitrary coefficient containers; I tried to incorporate some of the ideas from JuliaLang/julia#6837. I specifically focused on getting the implementation to make sense for vectors and matrices (nothing N>2). Having QuCoeffs also helps separate some of the logical concerns that arise for QuArrays. Now, we can think of our type structure the following way: 
   - Behavior of coefficients is defined with QuCoeffs 
   - Behavior of bases is defined with AbstractBasis 
   - Their combined/interacting behavior is defined with QuArray
2. QuArray coefficient containers are type-restricted to QuCoeffs (which themselves can hold whatever)
3. QuArray is no longer a subtype of AbstractArray. This allows for a much, much cleaner implementation of both the QuArray and QuCoeffs types. I think I'm seeing in action the argument that @Jutho's been making for a while now - at this point, QuArray behavior really does seem to deviate from the behavior defined on AbstractArrays. We'll have to implement our own printing methods, though :(
4. Minor cleanup/reorganization related to the introduction of QuCoeffs. Convience constructors (statevec, zero, eye) have moved to their own file. 

I'm really interested in getting @Jutho's eyes on this - my secret hope is that we could use TensorToolbox.jl to extend the functionality of (or maybe replace) QuCoeffs in the future.
