### PR TITLE
Tensor products for states and operators

### DIFF
--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -31,9 +31,15 @@ import Base: copy
     # Accessor functions #
     ######################
     coefftype{B,T,N,A}(::QuArray{B,T,N,A}) = A
-    rawcoeffs(qarr::QuArray) = qarr.coeffs
 
-    bases(qarr::QuArray, i) = qarr.bases[i]
+    rawcoeffs(qarr::QuArray) = qarr.coeffs
+    coeffs(qarr::QuArray) = rawcoeffs(qarr)
+
+    rawbases(qarr::QuArray, i) = qarr.bases[i]
+    bases(qarr::QuArray, i) = rawbases(qarr, i)
+    
+    # works generally as long as the single index form is defined
+    rawbases(qarr::AbstractQuArray) =  ntuple(ndims(qarr), i->rawbases(qarr, i))
     bases(qarr::AbstractQuArray) = ntuple(ndims(qarr), i->bases(qarr, i))
 
     copy(qa::QuArray) = QuArray(copy(qa.coeffs), copy(qa.bases))
@@ -68,11 +74,14 @@ import Base: copy
     ######################
     # Accessor functions #
     ######################
-    rawcoeffs(ct::CTranspose) = rawcoeffs(ct.qarr)
     coefftype{B,T,N,A}(::CTranspose{B,T,N,A}) = A
 
+    rawcoeffs(ct::CTranspose) = rawcoeffs(ct.qarr)
+    coeffs(ct::CTranspose) = rawcoeffs(ct)'
+
     revind(len, i) = len - (i-1)
-    bases(ct::CTranspose, i) = bases(ct.qarr, revind(ndims(ct), i))
+    rawbases(ct::CTranspose, i) = rawbases(ct.qarr, i)
+    bases(ct::CTranspose, i) = rawbases(ct, revind(ndims(ct), i))
 
     copy(ct::CTranspose) = CTranspose(copy(ct.qarr))
 

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -21,8 +21,7 @@
     #                                       array which corresponds to the provided 
     #                                       basis.
     #
-    # nfactors(basis::B) -> the number of factor bases for `basis`; this is `N`
-    #                       in `FiniteBasis{S,N}` 
+    # nfactors(basis::B) -> the number of factor bases for `basis`
     #
     # tensor(a::B, b::B) -> Take the tensor product of these two bases. This
     #                       function should optimally return a basis of same 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using QuBase.rawcoeffs
 using Base.Test
 
 include("multest.jl")
+include("tensortest.jl")

--- a/test/tensortest.jl
+++ b/test/tensortest.jl
@@ -1,0 +1,46 @@
+using QuBase.bases
+
+m = [1+1im 2+2im 3+3im 4+4im; 
+     5+5im 6+6im 7+7im 8+8im; 
+     9+9im 10+10im 11+11im 12+12im;
+     13+13im 14+14im 15+15im 16+16im]
+
+v = [1+1im, 2+2im, 3+3im, 4+4im]
+
+qm = QuArray(m, FiniteBasis(4,1), FiniteBasis(2,2))
+qv = QuArray(v)
+
+# operator ⊗ operator
+qm_qm = tensor(qm, qm)
+@assert rawcoeffs(qm_qm) == kron(m, m)
+@assert bases(qm_qm) == (tensor(bases(qm, 1), bases(qm, 1)), tensor(bases(qm, 2), bases(qm, 2)))
+
+qmc_qm = tensor(qm', qm)
+@assert rawcoeffs(qmc_qm) == kron(m', m)
+@assert bases(qmc_qm) == (tensor(bases(qm, 2), bases(qm, 1)), tensor(bases(qm, 1), bases(qm, 2)))
+
+qm_qmc = tensor(qm, qm')
+@assert rawcoeffs(qm_qmc) == kron(m, m')
+@assert bases(qm_qmc) == (tensor(bases(qm, 1), bases(qm, 2)), tensor(bases(qm, 2), bases(qm, 1)))
+
+qmc_qmc = tensor(qm', qm')
+@assert rawcoeffs(qmc_qmc) == kron(m, m)
+@assert bases(qmc_qmc) == (tensor(bases(qm, 2), bases(qm, 2)), tensor(bases(qm, 1), bases(qm, 1)))
+
+# state ⊗ state
+qv_qv = tensor(qv, qv)
+@assert rawcoeffs(qv_qv) == kron(v, v)
+@assert bases(qv_qv) == (tensor(bases(qv, 1), bases(qv, 1)),)
+
+qv_qvc = tensor(qv, qv')
+@assert rawcoeffs(qv_qvc) == kron(v, v')
+@assert bases(qv_qvc) == (bases(qv, 1), bases(qv, 1))
+
+qvc_qv = tensor(qv', qv)
+@assert rawcoeffs(qvc_qv) == kron(v', v)
+@assert bases(qvc_qv) == (bases(qv, 1), bases(qv, 1))
+
+qvc_qvc = tensor(qv', qv')
+@assert rawcoeffs(qvc_qvc) == kron(v, v)
+@assert bases(qvc_qvc) == (tensor(bases(qv, 1), bases(qv, 1)),)
+


### PR DESCRIPTION
This PR delivers a set of tensor product functions for QuArrays and their duals. Like our current set of multiplication functions, these functions only cover objects of N < 3 with orthonormal bases. 

In addition, I realized that having basis types parameterize the number of factors can break construction of QuArrays where bases along different dimensions have different numbers of factors, e.g.

```
qa = QuArray(randn(4,4), FiniteBasis(4), FiniteBasis(2,2))
ERROR: `QuArray{B<:AbstractBasis{S<:AbstractStructure},T,N,A}` has no method matching QuArray{B<:AbstractBasis{S<:AbstractStructure},T,N,A}(::Array{Float64,2}, ::(FiniteBasis{Orthonormal,1},FiniteBasis{Orthonormal,2}))
 in QuArray at /Users/jarrettrevels/.julia/QuBase/src/arrays/quarray.jl:24
```

I removed the factor parameterization for FiniteBasis in order to allow operations like |A⟩⟨B|⟨C| --> |A⟩⟨BC|. 
I don't explicitly know when that kind of operation would be useful, but I think it's mathematically valid to define linear maps between spaces with explicit factors (e.g. H_BC) to a space without explicit factors (e.g. H_A), so I went ahead and did so. I might be over-generalizing here... 
