### PR TITLE
Behavior of ctranspose.

### DIFF
--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -91,8 +91,13 @@ import Base: copy
     Base.setindex!(ct::CTranspose, x, i, j) = setindex!(ct.qarr, x', j, i)
     Base.setindex!(dv::DualVector, x, i) = setindex!(dv.qarr, x', i)
 
-    Base.ctranspose(qarr::QuArray) = CTranspose(qarr)
-    Base.ctranspose(ct::CTranspose) = ct.qarr
+    #Base.ctranspose(qarr::QuArray) = CTranspose(qarr)
+    function ctranspose(qarr::QuArray)
+        ctcoeffs = ctranspose(rawcoeffs(qarr))
+        return CTranspose(QuArray(ctcoeffs,bases(qarr)))
+    end
+
+    #Base.ctranspose(ct::CTranspose) = ct.qarr
 
 ######################
 # Printing Functions #


### PR DESCRIPTION
ctranpose has the following behavior :

For 
Input :

m = [1+1im 2+2im 3+3im; 
     4+4im 5+5im 6+6im; 
     7+7im 8+8im 9+9im]
qm = QuArray(m)
qm
3x3 QuMatrix in QuBase.FiniteBasis{QuBase.Orthonormal,1}:
...original coefficients: Array{Complex{Int64},2}
Complex{Int64}[1 + 1im 2 + 2im 3 + 3im
               4 + 4im 5 + 5im 6 + 6im
               7 + 7im 8 + 8im 9 + 9im]

c_qm = ctranspose(qm)
c_qm
3x3 DualMatrix in QuBase.FiniteBasis{QuBase.Orthonormal,1}:
...original coefficients: Array{Complex{Int64},2}
Complex{Int64}[1 + 1im 2 + 2im 3 + 3im
               4 + 4im 5 + 5im 6 + 6im
               7 + 7im 8 + 8im 9 + 9im]

In the above case the conjugate transpose is not performed. 

The pull request aims to fix this. Hope my understanding of the ctranspose is right. Please do comment. Thanks.
