### PR TITLE
Labeled Fock bases for QuArrays

### DIFF
--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -1,5 +1,3 @@
-import Base: copy
-
 ###########
 # QuArray #
 ###########
@@ -42,11 +40,11 @@ import Base: copy
     rawbases(qarr::AbstractQuArray) =  ntuple(ndims(qarr), i->rawbases(qarr, i))
     bases(qarr::AbstractQuArray) = ntuple(ndims(qarr), i->bases(qarr, i))
 
-    copy(qa::QuArray) = QuArray(copy(qa.coeffs), copy(qa.bases))
-
     ########################
     # Array-like functions #
     ########################
+    Base.copy(qa::QuArray) = QuArray(copy(qa.coeffs), copy(qa.bases))
+
     Base.size(qarr::QuArray, i...) = size(rawcoeffs(qarr), i...)
     Base.ndims(qarr::QuArray) = ndims(rawcoeffs(qarr))
     Base.length(qarr::QuArray) = length(rawcoeffs(qarr))
@@ -83,11 +81,11 @@ import Base: copy
     rawbases(ct::CTranspose, i) = rawbases(ct.qarr, i)
     bases(ct::CTranspose, i) = rawbases(ct, revind(ndims(ct), i))
 
-    copy(ct::CTranspose) = CTranspose(copy(ct.qarr))
-
     ########################
     # Array-like functions #
     ########################
+    Base.copy(ct::CTranspose) = CTranspose(copy(ct.qarr))
+
     Base.ndims(ct::CTranspose) = ndims(ct.qarr)
     Base.length(ct::CTranspose) = length(ct.qarr)
 
@@ -103,10 +101,20 @@ import Base: copy
     Base.ctranspose(qarr::QuArray) = CTranspose(qarr)
     Base.ctranspose(ct::CTranspose) = ct.qarr
 
+################
+# LabelQuArray #
+################
+    typealias LabelQuArray{B<:LabelBasis,T,N,A} QuArray{B,T,N,A}
+    typealias TupleArray{T<:Tuple,N} Array{T,N} 
+
+    Base.getindex(larr::LabelQuArray, tups::Union(Tuple,TupleArray)...) = getindex(larr, map(getindex, bases(larr), tups)...)
+    Base.setindex!(larr::LabelQuArray, x, tups::Union(Tuple,TupleArray)...) = setindex!(larr, x, map(getindex, bases(larr), tups)...)
+    
 ######################
 # Printing Functions #
 ######################
     Base.summary{B}(qarr::AbstractQuArray{B}) = "$(sizenotation(size(qarr))) $(typerepr(qarr)) in $B"
+    Base.summary(larr::LabelQuArray) = "$(sizenotation(size(larr))) $(typerepr(larr)) in labeled bases $(bases(larr))"
 
     function Base.show(io::IO, qarr::AbstractQuArray)
         println(io, summary(qarr)*":")

--- a/src/bases/bases.jl
+++ b/src/bases/bases.jl
@@ -44,6 +44,7 @@
 # Include Statements #
 ######################
     include("finitebasis.jl")
+    include("labelbasis.jl")
 
 export AbstractBasis,
     AbstractFiniteBasis,

--- a/src/bases/finitebasis.jl
+++ b/src/bases/finitebasis.jl
@@ -38,6 +38,7 @@
     Base.length(basis::FiniteBasis) = prod(basis.lens)
     Base.size(basis::FiniteBasis) = basis.lens
     Base.size(basis::FiniteBasis, i) = basis.lens[i]
+    
     nfactors{S,N}(::FiniteBasis{S,N}) = N
     checkcoeffs(coeffs, dim::Int, basis::FiniteBasis) = size(coeffs, dim) == length(basis) 
 

--- a/src/bases/labelbasis.jl
+++ b/src/bases/labelbasis.jl
@@ -1,0 +1,182 @@
+##############
+# LabelBasis #
+##############
+    # A LabelBasis uses precomputed values to generate labels 
+    # for given indices in the basis, or vice versa (an index 
+    # for a given state in the basis).
+    #
+    # For example:
+    #
+    #   julia> b = LabelBasis(2,2,2)
+    #   LabelBasis{Orthonormal,3}(0:1,0:1,0:1)
+    #
+    #   julia> collect(b)
+    #   8-element Array{Int64,Int64,Int64),1}:
+    #    (0,0,0)
+    #    (1,0,0)
+    #    (0,1,0)
+    #    (1,1,0)
+    #    (0,0,1)
+    #    (1,0,1)
+    #    (0,1,1)
+    #    (1,1,1)
+    #
+    #   julia> b[6]
+    #   (1,0,1)
+    #
+    #   julia> b[(1,0,1)]
+    #   6
+    # 
+    # Because the labels are generated rather than actually 
+    # stored, one can represent very large bases without 
+    # any storage overhead:
+    #
+    #   julia> b = LabelBasis(221,135,31,42,321,3)
+    #   LabelBasis{Orthonormal,6}(0:220,0:134,0:30,0:41,0:320,0:2)
+    #   
+    #   julia> length(b)
+    #   37407898710
+    #   
+    #   julia> last(b)
+    #   (220,134,30,41,320,2)
+    #   
+    #   julia> b[34234134]
+    #   (128,60,0,37,0,0)
+    #   
+    #   julia> b[(128,60,0,37,0,0)]
+    #   34234134
+    # 
+    # Arbitrary numeric ranges are supported for labels:
+    #   
+    #   julia> b = LabelBasis(0.0:0.1:0.2, 4:7)
+    #   LabelBasis{Orthonormal,2}(0.0:0.1:0.2,4:7)     
+    #       
+    #   julia> collect(b)
+    #   12-element Array{(Float64,Int64),1}:
+    #    (0.0,4)
+    #    (0.1,4)
+    #    (0.2,4)
+    #    (0.0,5)
+    #    (0.1,5)
+    #    (0.2,5)
+    #    (0.0,6)
+    #    (0.1,6)
+    #    (0.2,6)
+    #    (0.0,7)
+    #    (0.1,7)
+    #    (0.2,7)        
+    #
+    #   julia> b[b[(0.0, 7)]] == (0.0, 7)
+    #   true
+    #
+    # Since LabelBasis is iterable, you can apply filters. The below selects
+    # the labels for the X=2 subspace from the given basis:
+    #   
+    #   julia> collect(filter((x...)->sum(x...)==2, LabelBasis(4,4,4)))
+    #   6-element Array{Any,1}:
+    #    (2,0,0)
+    #    (1,1,0)
+    #    (0,2,0)
+    #    (1,0,1)
+    #    (0,1,1)
+    #    (0,0,2)
+    
+    immutable LabelBasis{S<:AbstractStructure,N} <: AbstractFiniteBasis{S}
+        ranges::NTuple{N,Range}
+        denoms::NTuple{N,Float64}
+        LabelBasis(ranges, denoms, ::Type{BypassFlag}) = new(ranges, denoms)
+        function LabelBasis(ranges::NTuple{N,Range})
+            # reverse is done to match cartesianmap order
+            return LabelBasis{S,N}(ranges, precompute_denoms(reverse(map(length,ranges))), BypassFlag) 
+        end
+
+    end
+
+    #resolves ambiguity warnings
+    LabelBasis{S<:AbstractStructure}(::(), ::Type{S}=Orthonormal) = error("LabelBasis requires a tuple of ranges as a constructor argument") 
+    
+    LabelBasis{S<:AbstractStructure,N}(lens::NTuple{N,Range}, ::Type{S}=Orthonormal) = LabelBasis{S,N}(lens)
+    LabelBasis{S<:AbstractStructure}(lens::(Int...), ::Type{S}=Orthonormal) = LabelBasis(map(n->zero(eltype(n)):(n-1), lens), S)
+    LabelBasis(lens...) = LabelBasis(lens)
+
+    Base.convert{A,B,N}(::Type{LabelBasis{A,N}}, b::LabelBasis{B,N}) = LabelBasis{A,N}(b.ranges, b.denoms, BypassFlag)
+    Base.convert{A,B,N}(::Type{FiniteBasis{A,N}}, b::LabelBasis{B,N}) = FiniteBasis{A,N}(size(b))
+
+    Base.copy{S,N}(b::LabelBasis{S,N}) = LabelBasis{S,N}(copy(b.ranges), copy(b.denoms), BypassFlag)
+
+    ####################
+    # Helper Functions #
+    ####################
+    # This function precomputes the 
+    # denominators for each factor of 
+    # the cartesian product.
+    #
+    # This site offers a thorough 
+    # explanation of this method:
+    # http://phrogz.net/lazy-cartesian-product
+    #
+    function precompute_denoms(lens)
+        # storing as Floats avoids number precision issues for 
+        # outrageously large bases
+        total_divisor = prod(float,lens) 
+        function get_denom(i)
+            total_divisor = div(total_divisor, i)
+            return max(1.0, total_divisor)
+        end
+        # reverse is done to match cartesianmap order
+        return reverse(map(get_denom, lens))
+    end
+
+    ######################
+    # Property Functions #
+    ######################
+    ranges(b::LabelBasis) = b.ranges
+    ranges(b::LabelBasis, i) = b.ranges[i]
+
+    Base.size(b::LabelBasis) = map(length, ranges(b))
+    Base.size(b::LabelBasis, i) = length(ranges(b, i))
+    Base.length(b::LabelBasis) = prod(length, ranges(b))
+
+    structure{S}(::Type{LabelBasis{S}}) = S
+    structure{S,N}(::Type{LabelBasis{S,N}}) = S
+
+    nfactors{S,N}(::LabelBasis{S,N}) = N
+    checkcoeffs(coeffs, dim, b::LabelBasis) = size(coeffs, dim) == length(b)
+
+    ######################
+    # Accessor Functions #
+    ######################
+    ind_value(n, range, denom, modulus) = range[(div(n, denom) % modulus)+1]
+    tuple_at_ind(b::LabelBasis, i) = ntuple(nfactors(b), x->ind_value(i-1, ranges(b,x), b.denoms[x], size(b,x)))
+    pos_in_range(r::Range, i) = i in r ? (i-first(r))/step(r) : throw(BoundsError())
+    getpos(b::LabelBasis, label) = int(sum(map(*, map(pos_in_range, ranges(b), label), b.denoms))+1)
+
+    Base.in(label, b::LabelBasis) = reduce(&, map(in, label, ranges(b)))
+
+    Base.getindex(b::LabelBasis, i) = tuple_at_ind(b, i)
+    Base.getindex(b::LabelBasis, t::Tuple) = getpos(b, t)
+    Base.getindex(b::LabelBasis, arr::AbstractArray) = [[b[i] for i in arr]...]
+
+    ######################
+    # Iterator Functions #
+    ######################
+    Base.start(::LabelBasis) = 1
+    Base.done(b::LabelBasis, state) = length(b) == state-1
+    Base.next(b::LabelBasis, state) = b[state], state+1
+    Base.endof(b::LabelBasis) = length(b)
+    Base.last(b::LabelBasis) = b[length(b)]
+    Base.first(b::LabelBasis) = b[1]
+    Base.collect(b::LabelBasis) = b[1:end]
+
+    ##########################
+    # Mathematical Functions #
+    ##########################
+    tensor{S}(a::LabelBasis{S}, b::LabelBasis{S}) = LabelBasis(tuple(a.ranges..., b.ranges...), S)
+
+    ######################
+    # Printing Functions #
+    ######################
+    Base.repr(b::LabelBasis) = "$(typeof(b))$(ranges(b))"
+    Base.show(io::IO, b::LabelBasis) = print(io, repr(b))
+
+export LabelBasis

--- a/test/labelbasistest.jl
+++ b/test/labelbasistest.jl
@@ -1,0 +1,22 @@
+m = [1+1im 2+2im 3+3im 4+4im; 
+     5+5im 6+6im 7+7im 8+8im; 
+     9+9im 10+10im 11+11im 12+12im;
+     13+13im 14+14im 15+15im 16+16im]
+
+qm = QuArray(m, LabelBasis(4,1), LabelBasis(2,2))
+qm_qm = tensor(qm,qm)
+
+@assert qm[(2,0),(1,0)] == qm[3,2]
+@assert qm'[(1,0),(2,0)] == qm[3,2]'
+@assert QuBase.bases(qm_qm) == (LabelBasis(4,1,4,1), LabelBasis(2,2,2,2))
+
+@assert qm_qm[(2,0,1,0),(1,1,0,1)] == qm_qm[7,12]
+qm_qm[(2,0,1,0),(1,1,0,1)] = 123
+@assert qm_qm[(2,0,1,0),(1,1,0,1)] == 123
+
+x2subspace = [filter((x...)->sum(x...)==2, QuBase.bases(qm_qm,2))...]
+@assert x2subspace == [(1,1,0,0),(1,0,1,0),(0,1,1,0),(1,0,0,1),(0,1,0,1),(0,0,1,1)]
+
+@assert qm_qm[(3,0,3,0), x2subspace] == [0+416im 0+392im 0+420im 0+420im 0+450im 0+416im]
+qm_qm[(3,0,3,0), x2subspace] = [1 2 3 4 5 6]
+@assert qm_qm[(3,0,3,0), x2subspace] == [1 2 3 4 5 6]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Base.Test
 
 include("multest.jl")
 include("tensortest.jl")
+include("labelbasistest.jl")

--- a/test/tensortest.jl
+++ b/test/tensortest.jl
@@ -43,4 +43,3 @@ qvc_qv = tensor(qv', qv)
 qvc_qvc = tensor(qv', qv')
 @assert rawcoeffs(qvc_qvc) == kron(v, v)
 @assert bases(qvc_qvc) == (tensor(bases(qv, 1), bases(qv, 1)),)
-


### PR DESCRIPTION
This PR implements a new basis type (`LabelBasis`) that allows label access into QuArrays by exploiting an assumed Fock structure. This is code that I've had floating around for a while, and I think it belongs here now.

I've written comments to describe how LabelBasis works, and the provided tests should give one an intuition of how it works with QuArrays.

The ability to use LabelBasis is more of an analytic feature than a computational one; while basis storage is very efficient, access time is relatively slow since the label indexing is generated on the fly (access complexity is mainly predicated on the number of basis factors, i.e. `N` in `LabelBasis{S,N}`). However, you can access a QuArray{B<:LabelBasis} using normal indexing as well as label indexing (getindex/setindex! is overloaded on QuArray{B<:LabelBasis} to treat only tuple arguments as labels), so there shouldn't be any significant performance hit for normal algorithms.
