### PR TITLE
Rename (anti)commutator to (anti)commute.

### DIFF
--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -129,15 +129,16 @@ end
 
 tensor{B<:OrthonormalBasis}(bra::DualVector{B}, ket::QuVector{B}) = tensor(ket, bra)
 
-##############
-# Commutator #
-##############
+###############
+# Commutators #
+###############
 
-commutator(a::AbstractQuMatrix, b::AbstractQuMatrix) = (a*b) - (b*a)
-anticommutator(a::AbstractQuMatrix, b::AbstractQuMatrix) = (a*b) + (b*a)
+# (anti)commute two QuMatrices and return result
+commute(a::AbstractQuMatrix, b::AbstractQuMatrix) = (a*b) - (b*a)
+anticommute(a::AbstractQuMatrix, b::AbstractQuMatrix) = (a*b) + (b*a)
 
 export normalize,
     normalize!,
     tensor,
-    commutator,
-    anticommutator
+    commute,
+    anticommute

--- a/test/operatortest.jl
+++ b/test/operatortest.jl
@@ -2,13 +2,13 @@
 # Spin Operators Test #
 #######################
 
-@assert commutator(sigma_x, sigma_y) == 2*im*sigma_z
-@assert commutator(sigma_y, sigma_z) == 2*im*sigma_x
-@assert commutator(sigma_z, sigma_x) == 2*im*sigma_y
+@assert commute(sigma_x, sigma_y) == 2*im*sigma_z
+@assert commute(sigma_y, sigma_z) == 2*im*sigma_x
+@assert commute(sigma_z, sigma_x) == 2*im*sigma_y
 
-@assert anticommutator(sigma_x, sigma_x) == 2 * sigma_x^2
+@assert anticommute(sigma_x, sigma_x) == 2 * sigma_x^2
 
-@assert coeffs(commutator(sigma_x, sigma_x)) == spzeros(2,2)
+@assert coeffs(commute(sigma_x, sigma_x)) == spzeros(2,2)
 
 ####################################################
 # Position, Displacement & Momentum Operators Test #
@@ -16,8 +16,8 @@
 
 p = positionop(2)
 m = momentumop(2)
-@assert coeffs(commutator(sigma_x, p)) == spzeros(2,2)
-@assert coeffs(commutator(sigma_y, m)) == spzeros(2,2)
+@assert coeffs(commute(sigma_x, p)) == spzeros(2,2)
+@assert coeffs(commute(sigma_y, m)) == spzeros(2,2)
 
 coherentstate_inf = QuBase.coherentstatevec_inf(20,1)
 coherentstate = displaceop(20,1)*statevec(1,FiniteBasis(20))

--- a/test/operatortest.jl
+++ b/test/operatortest.jl
@@ -2,30 +2,46 @@
 # Spin Operators Test #
 #######################
 
+# the Pauli spin matrices sigma_x, sigma_y and sigma_z obey the commutation
+# relations $ [\sigma_a, \sigma_b]  = 2i\epsion_{abc} \sigma_c $, where
+# $\epsion_{abc}$ is the Levi-Civita symbol.
+# Hence,
 @assert commute(sigma_x, sigma_y) == 2*im*sigma_z
 @assert commute(sigma_y, sigma_z) == 2*im*sigma_x
 @assert commute(sigma_z, sigma_x) == 2*im*sigma_y
 
-@assert anticommute(sigma_x, sigma_x) == 2 * sigma_x^2
-
 @assert coeffs(commute(sigma_x, sigma_x)) == spzeros(2,2)
+
+# Moreover, the sigmas fulfill anticommutation relations
+# ${\sigma_a, \sigma_b} = 2\delta_{a,b} I$ wit $\delta_{a,b}$
+# being the Kronecker delta and $I$ the 2x2 identity matrix
+# Thus,
+@assert anticommute(sigma_x, sigma_x) == 2 * QuArray(speye(2))
+
 
 ####################################################
 # Position, Displacement & Momentum Operators Test #
 ####################################################
 
+# position and momentum operators obey the commutation relation
+# $[x,p] = i I$, where $I$ is the identity operator
+# However, here we just use the fact that for n=2, x~sigma_x and
+# p ~ sigma_y
 p = positionop(2)
 m = momentumop(2)
 @assert coeffs(commute(sigma_x, p)) == spzeros(2,2)
 @assert coeffs(commute(sigma_y, m)) == spzeros(2,2)
 
-coherentstate_inf = QuBase.coherentstatevec_inf(20,1)
-coherentstate = displaceop(20,1)*statevec(1,FiniteBasis(20))
-@test_approx_eq_eps coeffs(coherentstate_inf)[1] coeffs(coherentstate)[1] 1e-8
+# test coefficients computed by coherentstatevec vs 
+# Fock basis coefficients
+coherentstate_inf = QuBase.coherentstatevec_inf(20,1.0)
+coherentstate = coherentstatevec(20, 1.0)
+@test_approx_eq_eps coherentstate_inf[1] coherentstate[1] 1e-8
+
 
 ############################
 # Squeezing Operators Test #
 ############################
 
 @assert squeezingop(2,1.0)== QuArray(eye(2))
-@test_approx_eq coeffs(squeezingop(lowerop(2), QuArray(eye(2)), 2.0)') coeffs(displaceop(2,1.0))
+@test_approx_eq coeffs(squeezingop(lowerop(2), QuArray(eye(2)), -2.0)) coeffs(displaceop(2,1.0))


### PR DESCRIPTION
IMHO this is more consistent with `scale`, `add` etc. Moreover, I would like to reserve `Commutator` and `Anticommutator` for lazy (anti)commutators or types representing the respective super-operators.
