### PR TITLE
Spin ops refactor for fewer temporary arrays and type stability

### DIFF
--- a/src/arrays/spinops.jl
+++ b/src/arrays/spinops.jl
@@ -1,71 +1,80 @@
 #########################
 # Spin Operator Methods #
 #########################
-
-immutable HalfSpin{S}
-    function HalfSpin()
-        S >= 0 ? new() : error("Spin must be positive")
-    end
+immutable HalfSpin{T<:Integer}
+    val::T
+    HalfSpin(val) = val >= 0 ? new(val) : error("Spin must be positive")
 end
 
-# The `spin` function takes the `j` argument from the value
-# domain to the type domain, making the `spin` function type unstable.
+HalfSpin{T}(val::T) = HalfSpin{T}(val)
 
-spin(j::Integer) = HalfSpin{2*j}()
-
-function spin(j::Float64)
+spin(s::HalfSpin) = s
+spin(j::Integer) = HalfSpin(2*j)
+function spin(j)
     if isinteger(j)       
         return spin(int(j)) # j = 0.0, 1.0, 2.0...
     elseif isinteger(2*j) 
-        return HalfSpin{int(2*j)}() # j = .5, 1.5, 2.5...
+        return HalfSpin(int(2*j)) # j = .5, 1.5, 2.5...
     else
         error("Spin must be a multiple of 1/2.")
     end
 end
 
-spin_value{S}(::HalfSpin{S}) = S/2
+spin_value(s::HalfSpin) = s.val/2
 
 #####################
 # Auxiliary Methods #
 #####################
+spin_coeffs(j, scalar) = [scalar*sqrt(j*(j+1)-(x+1)*x) for x in j-1:-1:-j]
 
-function mat_coeffs_1(j::Float64)
-    m = [j-1:-1:-j]
-    N = length(m)+1
-    m_coeffs = [sqrt(j*(j+1.0) - (x+1.0)*x) for x in m]
-    return spdiagm(m_coeffs,1,N,N)
+function spin_jxy_mat(s::HalfSpin, x_or_y)
+    N = s.val + 1
+    j = spin_value(s)
+
+    if x_or_y == :x
+        scalar = .5
+    elseif x_or_y == :y
+        scalar = -.5im
+    else
+        error("spin_jxy_mat can only construct matrices for :x or :y")
+    end
+
+    up_coeffs = spin_coeffs(j, scalar)
+    down_coeffs = x_or_y == :x ? up_coeffs : -1*up_coeffs
+    return spdiagm((up_coeffs, down_coeffs), (1, -1), N, N)
 end
 
-function mat_coeffs_2(j::Float64)
-    m = [j:-1:-j]
-    N = length(m)
-    return spdiagm(m,0,N,N)
+function spin_jpm_mat(s::HalfSpin, p_or_m)
+    N = s.val + 1
+    
+    if p_or_m == :p
+        k = 1
+    elseif p_or_m == :m
+        k = -1 
+    else
+        error("spin_jpm_mat can only construct matrices for :p or :m")
+    end
+    
+    return spdiagm(spin_coeffs(spin_value(s), 1), k, N, N)
 end
 
-function spin_h1(k::HalfSpin)
-    j = spin_value(k)
-    return mat_coeffs_1(j)
-end
-
-function spin_h2(k::HalfSpin)
-    j = spin_value(k)
-    return mat_coeffs_2(j)
+function spin_jz_mat(s::HalfSpin)
+    j = spin_value(s)
+    return spdiagm(j:-1:-j)
 end
 
 ################################
 # Jx, Jy, Jz, Jp, Jm operators #
 ################################
-
-spin_Jx(j) = QuArray(0.5*(spin_h1(spin(j))+spin_h1(spin(j))'))
-spin_Jy(j) = QuArray(-0.5*im*(spin_h1(spin(j))-spin_h1(spin(j))'))
-spin_Jz(j) = QuArray(spin_h2(spin(j)))
-spin_Jp(j) = QuArray(spin_h1(spin(j)))
-spin_Jm(j) = QuArray(spin_h1(spin(j))')
+spin_Jx(j) = QuArray(spin_jxy_mat(spin(j), :x))
+spin_Jy(j) = QuArray(spin_jxy_mat(spin(j), :y))
+spin_Jz(j) = QuArray(spin_jz_mat(spin(j)))
+spin_Jp(j) = QuArray(spin_jpm_mat(spin(j), :p))
+spin_Jm(j) = QuArray(spin_jpm_mat(spin(j), :m))
 
 ############################
 #  Pauli spin 1/2 matrices #
 ############################
-
 const sigma_x = 2.0 * spin_Jx(1/2)
 const sigma_y = 2.0 * spin_Jy(1/2)
 const sigma_z = 2.0 * spin_Jz(1/2)

--- a/src/arrays/spinops.jl
+++ b/src/arrays/spinops.jl
@@ -27,50 +27,40 @@ spin_value(s::HalfSpin) = s.val/2
 #####################
 spin_coeffs(j, scalar) = [scalar*sqrt(j*(j+1)-(x+1)*x) for x in j-1:-1:-j]
 
-function spin_jxy_mat(s::HalfSpin, x_or_y)
+function spin_jyx_mat(s::HalfSpin, a, b)
     N = s.val + 1
     j = spin_value(s)
-
-    if x_or_y == :x
-        scalar = .5
-    elseif x_or_y == :y
-        scalar = -.5im
-    else
-        error("spin_jxy_mat can only construct matrices for :x or :y")
-    end
-
-    up_coeffs = spin_coeffs(j, scalar)
-    down_coeffs = x_or_y == :x ? up_coeffs : -1*up_coeffs
+    up_coeffs = spin_coeffs(j, a)
+    down_coeffs = b == 1 ? up_coeffs : b * up_coeffs
     return spdiagm((up_coeffs, down_coeffs), (1, -1), N, N)
 end
 
-function spin_jpm_mat(s::HalfSpin, p_or_m)
+spin_jx_mat(j) = spin_jyx_mat(spin(j), .5, 1)
+spin_jy_mat(j) = spin_jyx_mat(spin(j), -.5im, -1)
+
+function spin_jpm_mat(s::HalfSpin, k)
     N = s.val + 1
-    
-    if p_or_m == :p
-        k = 1
-    elseif p_or_m == :m
-        k = -1 
-    else
-        error("spin_jpm_mat can only construct matrices for :p or :m")
-    end
-    
-    return spdiagm(spin_coeffs(spin_value(s), 1), k, N, N)
+    return spdiagm(spin_coeffs(spin_value(s), k), k, N, N)
 end
+
+spin_jp_mat(j) = spin_jpm_mat(spin(j), 1)
+spin_jm_mat(j) = spin_jpm_mat(spin(j), -1)
 
 function spin_jz_mat(s::HalfSpin)
     j = spin_value(s)
     return spdiagm(j:-1:-j)
 end
 
+spin_jz_mat(j) = spin_jz_mat(spin(j))
+
 ################################
 # Jx, Jy, Jz, Jp, Jm operators #
 ################################
-spin_Jx(j) = QuArray(spin_jxy_mat(spin(j), :x))
-spin_Jy(j) = QuArray(spin_jxy_mat(spin(j), :y))
-spin_Jz(j) = QuArray(spin_jz_mat(spin(j)))
-spin_Jp(j) = QuArray(spin_jpm_mat(spin(j), :p))
-spin_Jm(j) = QuArray(spin_jpm_mat(spin(j), :m))
+spin_Jx(j) = QuArray(spin_jx_mat(j))
+spin_Jy(j) = QuArray(spin_jy_mat(j))
+spin_Jz(j) = QuArray(spin_jz_mat(j))
+spin_Jp(j) = QuArray(spin_jp_mat(j))
+spin_Jm(j) = QuArray(spin_jm_mat(j))
 
 ############################
 #  Pauli spin 1/2 matrices #

--- a/src/arrays/spinops.jl
+++ b/src/arrays/spinops.jl
@@ -27,7 +27,7 @@ spin_value(s::HalfSpin) = s.val/2
 #####################
 spin_coeffs(j, scalar) = [scalar*sqrt(j*(j+1)-(x+1)*x) for x in j-1:-1:-j]
 
-function spin_jyx_mat(s::HalfSpin, a, b)
+function spinjyx_mat(s::HalfSpin, a, b)
     N = s.val + 1
     j = spin_value(s)
     up_coeffs = spin_coeffs(j, a)
@@ -35,52 +35,56 @@ function spin_jyx_mat(s::HalfSpin, a, b)
     return spdiagm((up_coeffs, down_coeffs), (1, -1), N, N)
 end
 
-spin_jx_mat(j) = spin_jyx_mat(spin(j), .5, 1)
-spin_jy_mat(j) = spin_jyx_mat(spin(j), -.5im, -1)
+spinjx_mat(j) = spinjyx_mat(spin(j), .5, 1)
+spinjy_mat(j) = spinjyx_mat(spin(j), -.5im, -1)
 
-function spin_jpm_mat(s::HalfSpin, k)
+function spinjpm_mat(s::HalfSpin, k)
     N = s.val + 1
     return spdiagm(spin_coeffs(spin_value(s), 1), k, N, N)
 end
 
-spin_jp_mat(j) = spin_jpm_mat(spin(j), 1)
-spin_jm_mat(j) = spin_jpm_mat(spin(j), -1)
+spinjp_mat(j) = spinjpm_mat(spin(j), 1)
+spinjm_mat(j) = spinjpm_mat(spin(j), -1)
 
-function spin_jz_mat(s::HalfSpin)
+function spinjz_mat(s::HalfSpin)
     j = spin_value(s)
     return spdiagm(j:-1:-j)
 end
 
-spin_jz_mat(j) = spin_jz_mat(spin(j))
+spinjz_mat(j) = spinjz_mat(spin(j))
 
 ################################
 # Jx, Jy, Jz, Jp, Jm operators #
 ################################
-# This Wikipedia pages give a nice overview of spin/ladder operators:
+# These Wikipedia pages give a nice overview of spin/ladder operators:
 # http://en.wikipedia.org/wiki/Spin_%28physics%29#Operator
 # http://en.wikipedia.org/wiki/Ladder_operator#Angular_momentum
-spin_Jx(j) = QuArray(spin_jx_mat(j))
-spin_Jy(j) = QuArray(spin_jy_mat(j))
-spin_Jz(j) = QuArray(spin_jz_mat(j))
-spin_Jp(j) = QuArray(spin_jp_mat(j))
-spin_Jm(j) = QuArray(spin_jm_mat(j))
+spinjx(j) = QuArray(spinjx_mat(j))
+spinjy(j) = QuArray(spinjy_mat(j))
+spinjz(j) = QuArray(spinjz_mat(j))
+spinjp(j) = QuArray(spinjp_mat(j))
+spinjm(j) = QuArray(spinjm_mat(j))
 
 ############################
 #  Pauli spin 1/2 matrices #
 ############################
-const sigma_x = 2.0 * spin_Jx(1/2)
-const sigma_y = 2.0 * spin_Jy(1/2)
-const sigma_z = 2.0 * spin_Jz(1/2)
+const sigmax = 2.0 * spinjx(1/2)
+const sigmay = 2.0 * spinjy(1/2)
+const sigmaz = 2.0 * spinjz(1/2)
+const sigmap = sigmax + im * sigmay
+const sigmam = sigmax - im * sigmay
 
-# TODO : unicode sigma_y, sigma_z
-const σₓ = sigma_x
+# TODO : unicode sigmay, sigmaz
+const σₓ = sigmax
 
-export spin_Jx,
-    spin_Jy,
-    spin_Jz,
-    spin_Jp,
-    spin_Jm,
-    sigma_x,
-    sigma_y,
-    sigma_z,
+export spinjx,
+    spinjy,
+    spinjz,
+    spinjp,
+    spinjm,
+    sigmax,
+    sigmay,
+    sigmaz,
+    sigmap,
+    sigmam,
     σₓ

--- a/src/arrays/spinops.jl
+++ b/src/arrays/spinops.jl
@@ -40,7 +40,7 @@ spin_jy_mat(j) = spin_jyx_mat(spin(j), -.5im, -1)
 
 function spin_jpm_mat(s::HalfSpin, k)
     N = s.val + 1
-    return spdiagm(spin_coeffs(spin_value(s), k), k, N, N)
+    return spdiagm(spin_coeffs(spin_value(s), 1), k, N, N)
 end
 
 spin_jp_mat(j) = spin_jpm_mat(spin(j), 1)
@@ -56,6 +56,9 @@ spin_jz_mat(j) = spin_jz_mat(spin(j))
 ################################
 # Jx, Jy, Jz, Jp, Jm operators #
 ################################
+# This Wikipedia pages give a nice overview of spin/ladder operators:
+# http://en.wikipedia.org/wiki/Spin_%28physics%29#Operator
+# http://en.wikipedia.org/wiki/Ladder_operator#Angular_momentum
 spin_Jx(j) = QuArray(spin_jx_mat(j))
 spin_Jy(j) = QuArray(spin_jy_mat(j))
 spin_Jz(j) = QuArray(spin_jz_mat(j))

--- a/test/operatortest.jl
+++ b/test/operatortest.jl
@@ -2,24 +2,24 @@
 # Spin Operators Test #
 #######################
 
-# the Pauli spin matrices sigma_x, sigma_y and sigma_z obey the commutation
+# the Pauli spin matrices sigmax, sigmay and sigmaz obey the commutation
 # relations $ [\sigma_a, \sigma_b]  = 2i\epsion_{abc} \sigma_c $, where
 # $\epsion_{abc}$ is the Levi-Civita symbol.
 # Hence,
-@assert commute(sigma_x, sigma_y) == 2*im*sigma_z
-@assert commute(sigma_y, sigma_z) == 2*im*sigma_x
-@assert commute(sigma_z, sigma_x) == 2*im*sigma_y
+@assert commute(sigmax, sigmay) == 2*im*sigmaz
+@assert commute(sigmay, sigmaz) == 2*im*sigmax
+@assert commute(sigmaz, sigmax) == 2*im*sigmay
 
-@assert coeffs(commute(sigma_x, sigma_x)) == spzeros(2,2)
+@assert coeffs(commute(sigmax, sigmax)) == spzeros(2,2)
 
 # Moreover, the sigmas fulfill anticommutation relations
-# ${\sigma_a, \sigma_b} = 2\delta_{a,b} I$ wit $\delta_{a,b}$
+# ${\sigma_a, \sigma_b} = 2\delta_{a,b} I$ with $\delta_{a,b}$
 # being the Kronecker delta and $I$ the 2x2 identity matrix
 # Thus,
-@assert anticommute(sigma_x, sigma_x) == 2 * QuArray(speye(2))
+@assert anticommute(sigmax, sigmax) == 2 * QuArray(speye(2))
 
-@assert spin_Jp(3.5) == spin_Jx(3.5) + (im * spin_Jy(3.5))
-@assert spin_Jm(3.5) == spin_Jx(3.5) - (im * spin_Jy(3.5))
+@assert spinjp(3.5) == spinjx(3.5) + (im * spinjy(3.5))
+@assert spinjm(3.5) == spinjx(3.5) - (im * spinjy(3.5))
 
 ####################################################
 # Position, Displacement & Momentum Operators Test #
@@ -27,12 +27,12 @@
 
 # position and momentum operators obey the commutation relation
 # $[x,p] = i I$, where $I$ is the identity operator
-# However, here we just use the fact that for n=2, x~sigma_x and
-# p ~ sigma_y
+# However, here we just use the fact that for n=2, x~sigmax and
+# p ~ sigmay
 p = positionop(2)
 m = momentumop(2)
-@assert coeffs(commute(sigma_x, p)) == spzeros(2,2)
-@assert coeffs(commute(sigma_y, m)) == spzeros(2,2)
+@assert coeffs(commute(sigmax, p)) == spzeros(2,2)
+@assert coeffs(commute(sigmay, m)) == spzeros(2,2)
 
 # test coefficients computed by coherentstatevec vs 
 # Fock basis coefficients

--- a/test/operatortest.jl
+++ b/test/operatortest.jl
@@ -18,6 +18,8 @@
 # Thus,
 @assert anticommute(sigma_x, sigma_x) == 2 * QuArray(speye(2))
 
+@assert spin_Jp(3.5) == spin_Jx(3.5) + (im * spin_Jy(3.5))
+@assert spin_Jm(3.5) == spin_Jx(3.5) - (im * spin_Jy(3.5))
 
 ####################################################
 # Position, Displacement & Momentum Operators Test #


### PR DESCRIPTION
The type instability of `spin` was making me uneasy, so I fixed it by making it an actual value, which I'm now convinced makes more sense in this context. 

In addition, this PR refactors the construction functions we had to avoid making as many temporary arrays.
