### PR TITLE
Generalized CTranspose + conversion methods and promotion rules

### DIFF
--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -27,13 +27,13 @@ end
 # operator * ket -> ket
 function *{B<:OrthonormalBasis}(op::AbstractQuMatrix{B}, ket::AbstractQuVector{B})
     vc = rawcoeffs(op)*rawcoeffs(ket)
-    QAT = similar_type(typeof(ket))
+    QAT = similar_type(ket)
     return QAT(vc, bases(op,1))
 end
 
 function *{B<:OrthonormalBasis}(op::DualMatrix{B}, ket::AbstractQuVector{B})
     vc = Ac_mul_B(rawcoeffs(op), rawcoeffs(ket))
-    QAT = similar_type(typeof(ket))
+    QAT = similar_type(ket)
     return QAT(vc, bases(op,1))
 end
 
@@ -50,29 +50,27 @@ end
 
 function *{B<:OrthonormalBasis}(dm::DualMatrix{B}, qm::AbstractQuMatrix{B})
     mc = Ac_mul_B(rawcoeffs(dm), rawcoeffs(qm))
-    QAT = similar_type(typeof(qm))
+    QAT = similar_type(qm)
     return QAT(mc, bases(dm,1), bases(qm,2))
 end
 
 function *{B<:OrthonormalBasis}(qm::AbstractQuMatrix{B}, dm::DualMatrix{B})
     mc = A_mul_Bc(rawcoeffs(dm), rawcoeffs(qm))
-    QAT = similar_type(typeof(qm))
+    QAT = similar_type(qm)
     return QAT(mc, bases(qm,1), bases(dm,2))
 end
 
 function *{B<:OrthonormalBasis}(qm1::AbstractQuMatrix{B}, qm2::AbstractQuMatrix{B})
     mc = rawcoeffs(qm1)*rawcoeffs(qm2)
-    QAT = similar_type(promote_type(typeof(qm1), typeof(qm2)))
+    QAT = similar_type(qm1, qm2)
     return QAT(mc, bases(qm1,1), bases(qm2,2))
 end
-
-
 
 # addition and subtraction
 function +{B<:AbstractBasis}(qarr1::AbstractQuArray{B}, qarr2::AbstractQuArray{B})
     if bases(qarr1) == bases(qarr2)
         sc = coeffs(qarr1) + coeffs(qarr2)
-        QAT = similar_type(promote_type(typeof(qarr1), typeof(qarr2))) 
+        QAT = similar_type(qarr1, qarr2)
         return QAT(sc, bases(qarr1))
     else
         error("Bases not compatible")
@@ -82,7 +80,7 @@ end
 function -{B<:AbstractBasis}(qarr1::AbstractQuArray{B}, qarr2::AbstractQuArray{B})
     if bases(qarr1) == bases(qarr2)
         sc = coeffs(qarr1) - coeffs(qarr2)
-        QAT = similar_type(promote_type(typeof(qarr1), typeof(qarr2))) 
+        QAT = similar_type(qarr1, qarr2)
         return QAT(sc, bases(qarr1))
     else
         error("Bases not compatible")
@@ -92,7 +90,6 @@ end
 +(ct1::CTranspose, ct2::CTranspose) = (ct1.qarr+ct2.qarr)'
 -(ct1::CTranspose, ct2::CTranspose) = (ct1.qarr-ct2.qarr)'
 
-
 # scaling
 Base.scale!(num::Number, qarr::AbstractQuArray) = (scale!(num, rawcoeffs(qarr)); return qarr)
 Base.scale!(num::Number, ct::CTranspose) = CTranspose(scale!(num', ct.qarr))
@@ -100,7 +97,7 @@ Base.scale!(qarr::AbstractQuArray, num::Number) = scale!(num, qarr)
 
 function Base.scale(num::Number, qarr::AbstractQuArray)
     fc = scale(num, rawcoeffs(qarr))
-    QAT = QuBase.similar_type(typeof(qarr))
+    QAT = similar_type(qarr)
     return QAT(fc, bases(qarr))
 end
 Base.scale(num::Number, ct::CTranspose) = CTranspose(scale(num', ct.qarr))
@@ -109,7 +106,6 @@ Base.scale(qarr::AbstractQuArray, num::Number) = scale(num, qarr)
 *(num::Number, qarr::AbstractQuArray) = scale(num, qarr)
 *(qarr::AbstractQuArray, num::Number) = scale(qarr, num)
 /(qarr::AbstractQuArray, num::Number) = scale(1/num, qarr)
-
 
 # matrix operations returning a scalar
 # normalization
@@ -122,12 +118,11 @@ end
 
 normalize(qarr::AbstractQuArray) = normalize!(copy(qarr))
 
-
 # matrix operations returning an array
 # sparse to dense
 function Base.full(qarr::AbstractQuMatrix)
     fc = full(rawcoeffs(qarr))
-    QAT = similar_type(typeof(qarr))
+    QAT = similar_type(qarr)
     return QAT(fc, bases(qarr))
 end
 #Base.full(ct::CTranspose) = full(ct.qarr)'
@@ -135,7 +130,7 @@ end
 # exponential of dense matrix
 function Base.expm(qarr::AbstractQuMatrix)
     fc = expm(full(rawcoeffs(qarr)))
-    QAT = similar_type(typeof(qarr))
+    QAT = similar_type(qarr)
     return QAT(fc, bases(qarr))
 end
 #Base.expm(ct::CTranspose) = expm(ct.qarr)'

--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -152,7 +152,7 @@ tensor(ct1::DualVector, ct2::DualVector) = tensor(ct1.qarr, ct2.qarr)'
 
 function tensor(ket::AbstractQuVector, bra::DualVector)
     tc = kron(coeffs(ket), coeffs(bra))
-    QAT = similar_type(ket, bra)
+    QAT = similar_type(ket)
     return QAT(tc, bases(ket,1), bases(bra,1))
 end
 

--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -135,30 +135,28 @@ function Base.expm(qarr::AbstractQuMatrix)
 end
 #Base.expm(ct::CTranspose) = expm(ct.qarr)'
 
-
 ##################
 # Tensor Product #
 ##################
 
 # General tensor product definitions for orthonormal bases
-function tensor{B<:OrthonormalBasis,T1,T2,N}(qarr1::AbstractQuArray{B,T1,N}, qarr2::AbstractQuArray{B,T2,N})
+function tensor{B,T1,T2,N}(qarr1::AbstractQuArray{B,T1,N}, qarr2::AbstractQuArray{B,T2,N})
     tc = kron(coeffs(qarr1), coeffs(qarr2))
-    QAT = similar_type(promote_type(typeof(qarr1), typeof(qarr2))) 
+    QAT = similar_type(qarr1, qarr2)
     return QAT(tc, map(tensor, bases(qarr1), bases(qarr2)))
 end
 
-function tensor{B<:OrthonormalBasis,T1,T2,N}(qarr1::CTranspose{B,T1,N}, qarr2::CTranspose{B,T2,N})
-    return QuArray(kron(rawcoeffs(qarr1), rawcoeffs(qarr2)),
-                   map(tensor, rawbases(qarr1), rawbases(qarr2)))'
-end
+# defined to resolve ambiguity warnings
+tensor{B}(ct1::DualVector{B}, ct2::DualVector{B}) = tensor(ct1.qarr, ct2.qarr)'
+tensor{B}(ct1::CTranspose{B}, ct2::CTranspose{B}) = tensor(ct1.qarr, ct2.qarr)'
 
-function tensor{B<:OrthonormalBasis}(ket::QuVector{B}, bra::DualVector{B})
+function tensor{B}(ket::AbstractQuVector{B}, bra::DualVector{B})
     return QuArray(kron(coeffs(ket), coeffs(bra)),
                    bases(ket,1),
                    bases(bra,1))
 end
 
-tensor{B<:OrthonormalBasis}(bra::DualVector{B}, ket::QuVector{B}) = tensor(ket, bra)
+tensor{B}(bra::DualVector{B}, ket::AbstractQuVector{B}) = tensor(ket, bra)
 
 ###############
 # Commutators #

--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -139,24 +139,24 @@ end
 # Tensor Product #
 ##################
 
-# General tensor product definitions for orthonormal bases
-function tensor{B,T1,T2,N}(qarr1::AbstractQuArray{B,T1,N}, qarr2::AbstractQuArray{B,T2,N})
+# General tensor product definitions
+function tensor{B1,B2,T1,T2,N}(qarr1::AbstractQuArray{B1,T1,N}, qarr2::AbstractQuArray{B2,T2,N})
     tc = kron(coeffs(qarr1), coeffs(qarr2))
     QAT = similar_type(qarr1, qarr2)
     return QAT(tc, map(tensor, bases(qarr1), bases(qarr2)))
 end
 
 # defined to resolve ambiguity warnings
-tensor{B}(ct1::DualVector{B}, ct2::DualVector{B}) = tensor(ct1.qarr, ct2.qarr)'
-tensor{B}(ct1::CTranspose{B}, ct2::CTranspose{B}) = tensor(ct1.qarr, ct2.qarr)'
+tensor(ct1::DualVector, ct2::DualVector) = tensor(ct1.qarr, ct2.qarr)'
+tensor(ct1::CTranspose, ct2::CTranspose) = tensor(ct1.qarr, ct2.qarr)'
 
-function tensor{B}(ket::AbstractQuVector{B}, bra::DualVector{B})
-    return QuArray(kron(coeffs(ket), coeffs(bra)),
-                   bases(ket,1),
-                   bases(bra,1))
+function tensor(ket::AbstractQuVector, bra::DualVector)
+    tc = kron(coeffs(ket), coeffs(bra))
+    QAT = similar_type(ket, bra)
+    return QAT(tc, bases(ket,1), bases(bra,1))
 end
 
-tensor{B}(bra::DualVector{B}, ket::AbstractQuVector{B}) = tensor(ket, bra)
+tensor(bra::DualVector, ket::AbstractQuVector) = tensor(ket, bra)
 
 ###############
 # Commutators #

--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -147,8 +147,8 @@ function tensor{B1,B2,T1,T2,N}(qarr1::AbstractQuArray{B1,T1,N}, qarr2::AbstractQ
 end
 
 # defined to resolve ambiguity warnings
-tensor(ct1::DualVector, ct2::DualVector) = tensor(ct1.qarr, ct2.qarr)'
 tensor(ct1::CTranspose, ct2::CTranspose) = tensor(ct1.qarr, ct2.qarr)'
+tensor(ct1::DualVector, ct2::DualVector) = tensor(ct1.qarr, ct2.qarr)'
 
 function tensor(ket::AbstractQuVector, bra::DualVector)
     tc = kron(coeffs(ket), coeffs(bra))

--- a/src/arrays/constructors.jl
+++ b/src/arrays/constructors.jl
@@ -12,6 +12,7 @@
         QAT = similar_type(typeof(qa))
         return QAT(fc, bases(qa))
     end
+
     function Base.eye(qa::AbstractQuArray)
         fc = eye(coeffs(qa))
         QAT = similar_type(typeof(qa))

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -120,10 +120,12 @@
     Base.length(ct::CTranspose) = length(ct.qarr)
 
     Base.size(ct::CTranspose) = reverse(size(ct.qarr))
-    Base.size(ct::CTranspose, i) = size(ct, revind(ndims(ct), i))
+    Base.size(ct::CTranspose, i) = size(ct.qarr, revind(ndims(ct), i))
 
     Base.getindex(ct::CTranspose, i, j) = getindex(ct.qarr, j, i)'
     Base.getindex(dv::DualVector, i) = getindex(dv.qarr, i)'
+
+    Base.in(c, ct::CTranspose) = in(c', ct.qarr)
 
     Base.setindex!(ct::CTranspose, x, i, j) = setindex!(ct.qarr, x', j, i)
     Base.setindex!(dv::DualVector, x, i) = setindex!(dv.qarr, x', i)

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -136,12 +136,18 @@
 ################
 # LabelQuArray #
 ################
-    typealias LabelQuArray{B<:LabelBasis,T,N,A} QuArray{B,T,N,A}
+    typealias LabeledQuArray{B<:LabelBasis,T,N} AbstractQuArray{B,T,N}
     typealias TupleArray{T<:Tuple,N} Array{T,N}
 
-    Base.getindex(larr::LabelQuArray, tups::Union(Tuple,TupleArray)...) = getindex(larr, map(getindex, bases(larr), tups)...)
-    Base.setindex!(larr::LabelQuArray, x, tups::Union(Tuple,TupleArray)...) = setindex!(larr, x, map(getindex, bases(larr), tups)...)
+    # redudant definitions added to resolve ambiguity warnings
+    Base.getindex{B<:LabelBasis}(larr::DualVector{B}, tups::Union(Tuple,TupleArray)) = getindex(larr, bases(larr,1)[tups])
+    Base.getindex{B<:LabelBasis}(larr::CTranspose{B}, tups::Union(Tuple,TupleArray)...) = getindex(larr, map(getindex, bases(larr), tups)...)
+    Base.getindex(larr::LabeledQuArray, tups::Union(Tuple,TupleArray)...) = getindex(larr, map(getindex, bases(larr), tups)...)
 
+    # redudant definitions added to resolve ambiguity warnings
+    Base.setindex!{B<:LabelBasis}(larr::DualVector{B}, x, tups::Union(Tuple,TupleArray)) = setindex(larr, x, bases(larr,1)[tups])
+    Base.setindex!{B<:LabelBasis}(larr::CTranspose{B}, x, tups::Union(Tuple,TupleArray)...) = setindex!(larr, x, map(getindex, bases(larr), tups)...)
+    Base.setindex!(larr::LabeledQuArray, x, tups::Union(Tuple,TupleArray)...) = setindex!(larr, x, map(getindex, bases(larr), tups)...)
 
 ########################
 # Conversion/Promotion #
@@ -162,14 +168,13 @@
 # Printing Functions #
 ######################
     Base.summary{B}(qarr::AbstractQuArray{B}) = "$(sizenotation(size(qarr))) $(typerepr(qarr)) in $B"
-    Base.summary(larr::LabelQuArray) = "$(sizenotation(size(larr))) $(typerepr(larr)) in labeled bases $(bases(larr))"
+    Base.summary(larr::LabeledQuArray) = "$(sizenotation(size(larr))) $(typerepr(larr)) in labeled bases $(bases(larr))"
 
     function Base.show(io::IO, qarr::AbstractQuArray)
         println(io, summary(qarr)*":")
         println(io, "...coefficients: $(coefftype(qarr))")
         print(io, repr(coeffs(qarr)))
     end
-
 
 ####################
 # Helper Functions #

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -88,8 +88,8 @@
     CTranspose{B<:AbstractBasis,T,N}(qa::AbstractQuArray{B,T,N}) = CTranspose{B,T,N,typeof(qa)}(qa)
     CTranspose{B<:AbstractBasis,T,N}(coeffs::AbstractArray{T,N}, bases::NTuple{N,B}) = CTranspose(QuArray(coeffs, bases))
 
-    typealias DualVector{B,T,Q} CTranspose{B,T,1,Q}
-    typealias DualMatrix{B,T,Q} CTranspose{B,T,2,Q}
+    typealias DualVector{B<:AbstractBasis,T,Q} CTranspose{B,T,1,Q}
+    typealias DualMatrix{B<:AbstractBasis,T,Q} CTranspose{B,T,2,Q}
 
     ######################
     # Accessor functions #

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -19,6 +19,9 @@
     ########################
     # Array-like functions #
     ########################
+    Base.eltype{B,T,N}(::AbstractQuArray{B,T,N}) = T
+    Base.eltype{B,T,N}(::Type{AbstractQuArray{B,T,N}}) = T
+
     Base.size(qarr::AbstractQuArray, i...) = size(rawcoeffs(qarr), i...)
     Base.ndims(qarr::AbstractQuArray) = ndims(rawcoeffs(qarr))
     Base.length(qarr::AbstractQuArray) = length(rawcoeffs(qarr))
@@ -67,13 +70,18 @@
     # Accessor functions #
     ######################
     coefftype{B,T,N,A}(::QuArray{B,T,N,A}) = A
+    coefftype{B,T,N,A}(::Type{QuArray{B,T,N,A}}) = A
 
     rawcoeffs(qarr::QuArray) = qarr.coeffs
 
     rawbases(qarr::QuArray) = qarr.bases
     rawbases(qarr::QuArray, i) = qarr.bases[i]
 
+    ########################
+    # Array-like functions #
+    ########################
     Base.copy(qa::QuArray) = QuArray(copy(qa.coeffs), copy(qa.bases))
+    Base.eltype{B,T,N,A}(::Type{QuArray{B,T,N,A}}) = T
 
 ##############
 # CTranspose #
@@ -95,6 +103,7 @@
     # Accessor functions #
     ######################
     coefftype(ct::CTranspose) = coefftype(ct.qarr)
+    coefftype{B,T,N,Q}(::Type{CTranspose{B,T,N,Q}}) = coefftype(Q)
 
     rawcoeffs(ct::CTranspose) = rawcoeffs(ct.qarr)
     coeffs(ct::CTranspose) = rawcoeffs(ct)'
@@ -114,6 +123,8 @@
     ########################
     # Array-like functions #
     ########################
+    Base.eltype{B,T,N,Q}(::Type{CTranspose{B,T,N,Q}}) = T
+
     Base.copy(ct::CTranspose) = CTranspose(copy(ct.qarr))
 
     Base.ndims(ct::CTranspose) = ndims(ct.qarr)

--- a/src/arrays/quarray.jl
+++ b/src/arrays/quarray.jl
@@ -33,6 +33,8 @@
     typealias AbstractQuVector{B<:AbstractBasis,T} AbstractQuArray{B,T,1}
     typealias AbstractQuMatrix{B<:AbstractBasis,T} AbstractQuArray{B,T,2}
 
+    similar_type{Q<:AbstractQuArray}(::Q) = similar_type(Q)
+    similar_type{A<:AbstractQuArray,B<:AbstractQuArray}(::A,::B) = similar_type(promote_type(A,B))
 
 ###########
 # QuArray #
@@ -60,7 +62,6 @@
     # the constructor should construct an instance from a coefficient container
     # and a tuple of bases (see  QuArray(coeffs, bases) above)
     similar_type{Q<:QuArray}(::Type{Q}) = QuArray
-
 
     ######################
     # Accessor functions #

--- a/src/bases/finitebasis.jl
+++ b/src/bases/finitebasis.jl
@@ -18,28 +18,27 @@
     # This tensor product basis, F_4 x F_3 x F_2, could be represented 
     # by calling FiniteBasis(4, 3, 2). 
 
-    immutable FiniteBasis{S,N} <: AbstractFiniteBasis{S}
-        lens::NTuple{N,Int}
-        FiniteBasis(lens::NTuple{N,Int}) = new(lens)
+    immutable FiniteBasis{S} <: AbstractFiniteBasis{S}
+        lens::@compat(Tuple{Vararg{Int}})
+        FiniteBasis(lens::@compat(Tuple{Vararg{Int}})) = new(lens)
         FiniteBasis(lens::Int...) = new(lens)
     end
 
-    FiniteBasis{N, S<:AbstractStructure}(lens::NTuple{N,Int}, ::Type{S}=Orthonormal) = FiniteBasis{S,N}(lens)
+    FiniteBasis{S<:AbstractStructure}(lens::@compat(Tuple{Vararg{Int}}), ::Type{S}=Orthonormal) = FiniteBasis{S}(lens)
     FiniteBasis(lens::Int...) = FiniteBasis(lens)
 
-    Base.convert{A,B,N}(::Type{FiniteBasis{A,N}}, f::FiniteBasis{B,N}) = FiniteBasis(f.lens, A)
+    Base.convert{A,B}(::Type{FiniteBasis{A}}, f::FiniteBasis{B}) = FiniteBasis(f.lens, A)
 
     ######################
     # Property Functions #
     ######################
     structure{S}(::Type{FiniteBasis{S}}) = S
-    structure{S,N}(::Type{FiniteBasis{S,N}}) = S
 
     Base.length(basis::FiniteBasis) = prod(basis.lens)
     Base.size(basis::FiniteBasis) = basis.lens
     Base.size(basis::FiniteBasis, i) = basis.lens[i]
     
-    nfactors{S,N}(::FiniteBasis{S,N}) = N
+    nfactors(basis::FiniteBasis) = length(basis.lens)
     checkcoeffs(coeffs, dim::Int, basis::FiniteBasis) = size(coeffs, dim) == length(basis) 
 
     ##########################

--- a/test/arraytest.jl
+++ b/test/arraytest.jl
@@ -1,0 +1,69 @@
+# The purpose of this file is to test 
+# the basic (i.e. non-mathematical) functions 
+# of values with type Q<:AbstractQuArray.
+
+###########
+# QuArray #
+###########
+qa_coeffs = rand(Complex{Float64},4,8)
+qa_basis = tuple(FiniteBasis(2,2), FiniteBasis(4,2))
+qa = QuArray(qa_coeffs, qa_basis)
+
+@assert coeffs(qa) == qa_coeffs
+@assert rawcoeffs(qa) == qa_coeffs
+@assert coefftype(qa) == typeof(qa_coeffs)
+@assert QuBase.similar_type(qa) == QuArray
+@assert length(qa) == length(qa_coeffs)
+@assert size(qa) == size(qa_coeffs)
+@assert size(qa,1) == size(qa_coeffs,1)
+@assert ndims(qa) == ndims(qa_coeffs)
+
+rand_i = rand(1:size(qa,1))
+rand_j = rand(1:size(qa,2))
+
+@assert qa[rand_i, rand_j] == qa_coeffs[rand_i, rand_j]
+
+c = rand(Complex{Float64})
+qa[rand_i, rand_j] = c
+
+@assert qa[rand_i, rand_j] == qa_coeffs[rand_i, rand_j] == c
+@assert in(qa[rand_i, rand_j], qa)
+@assert qa == copy(qa)
+
+@assert bases(qa) == qa_basis
+@assert bases(qa,1) == qa_basis[1]
+@assert rawbases(qa) == qa_basis
+@assert rawbases(qa,2) == qa_basis[2]
+
+##############
+# CTranspose #
+##############
+qac = qa'
+
+@assert coeffs(qac) == qa_coeffs'
+@assert rawcoeffs(qac) == qa_coeffs
+@assert coefftype(qac) == coefftype(qa)
+@assert QuBase.similar_type(qac) == CTranspose
+@assert length(qac) == length(qa)
+@assert size(qac) == reverse(size(qa))
+@assert size(qac,1) == size(qa,2)
+@assert ndims(qac) == ndims(qa)
+@assert qac[rand_j, rand_i] == qa[rand_i, rand_j]'
+
+c = rand(Complex{Float64})
+qac[rand_j, rand_i] = c
+
+@assert qac[rand_j, rand_i] == qa[rand_i, rand_j]' == c
+@assert in(qac[rand_j, rand_i], qac)
+
+@assert qac == copy(qac)
+
+@assert bases(qac) == reverse(bases(qa))
+@assert bases(qac,1) == bases(qa,2)
+@assert rawbases(qac) == bases(qa)
+@assert rawbases(qac,2) == bases(qa,2)
+
+qac_eager = QuBase.eager_ctranspose(qa)
+
+@assert convert(QuBase.qarr_type(qac), qac) == qac_eager
+@assert qac == qac_eager

--- a/test/arraytest.jl
+++ b/test/arraytest.jl
@@ -35,6 +35,13 @@ qa[rand_i, rand_j] = c
 @assert rawbases(qa) == qa_basis
 @assert rawbases(qa,2) == qa_basis[2]
 
+mock_type = QuArray{FiniteBasis{Orthonormal}, BigFloat, 2, Matrix{BigFloat}}
+prom_T = promote_type(eltype(qa), eltype(mock_type))
+prom_A = promote_type(coefftype(qa), coefftype(mock_type))
+prom_result = QuArray{FiniteBasis{Orthonormal}, prom_T, 2, prom_A}
+
+@assert promote_type(typeof(qa), mock_type) == prom_result
+
 ##############
 # CTranspose #
 ##############
@@ -67,3 +74,4 @@ qac_eager = QuBase.eager_ctranspose(qa)
 
 @assert convert(QuBase.qarr_type(qac), qac) == qac_eager
 @assert qac == qac_eager
+@assert promote_type(typeof(qac), mock_type) == prom_result

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using QuBase
 using Base.Test
 
+include("arraytest.jl")
 include("multest.jl")
 include("tensortest.jl")
 include("labelbasistest.jl")

--- a/test/tensortest.jl
+++ b/test/tensortest.jl
@@ -43,3 +43,13 @@ qvc_qv = tensor(qv', qv)
 qvc_qvc = tensor(qv', qv')
 @assert rawcoeffs(qvc_qvc) == kron(v, v)
 @assert bases(qvc_qvc) == (tensor(bases(qv, 1), bases(qv, 1)),)
+
+# n-ary version of tensor
+a = QuArray(rand(Complex{Float64},4), FiniteBasis(2,2))
+b = QuArray(rand(Complex{Float64},1), FiniteBasis(1,1))
+c = QuArray(rand(Complex{Float64},3))
+
+abc = tensor(a,b,c)
+@assert abc == tensor(tensor(a, b), c)
+@assert abc == tensor(a, tensor(b, c))
+

--- a/test/tensortest.jl
+++ b/test/tensortest.jl
@@ -50,6 +50,10 @@ b = QuArray(rand(Complex{Float64},1), FiniteBasis(1,1))
 c = QuArray(rand(Complex{Float64},3))
 
 abc = tensor(a,b,c)
-@assert abc == tensor(tensor(a, b), c)
-@assert abc == tensor(a, tensor(b, c))
+ab_c = tensor(tensor(a, b), c)
+a_bc = tensor(a, tensor(b, c))
 
+@assert bases(abc) == bases(ab_c)
+@assert bases(abc) == bases(a_bc)
+@test_approx_eq coeffs(abc) coeffs(ab_c) 
+@test_approx_eq coeffs(abc) coeffs(a_bc) 


### PR DESCRIPTION
This PR generalizes the `CTranspose` type to store `Q<:AbstractQuArray` and supplies the appropriate promotion rules and conversion methods. Once this is merged, we can close #31.

The only thing left before merging this in (unless something needs to be altered or I missed something) is to add some tests.

(I also snuck in a generalization of `LabeledQuArray`, a type alias that probably won't see much love for a while but for which I have future plans).

This also makes it simpler to call `similar_type` by adding a method that auto-extracts the type of a value argument (and promotes the types of two value arguments).
