### PR TITLE
Pauli to dense, matrix division and tests added.

### DIFF
--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -107,6 +107,20 @@ Base.scale(qarr::AbstractQuArray, num::Number) = scale(num, qarr)
 *(qarr::AbstractQuArray, num::Number) = scale(qarr, num)
 /(qarr::AbstractQuArray, num::Number) = scale(1/num, qarr)
 
+# Matrix Division, A*X=B, X = \(A,B), where A and B are of type AbstractQuMatrix
+function \{B<:OrthonormalBasis}(qm1::AbstractQuMatrix{B}, qm2::AbstractQuMatrix{B})
+    div = \(coeffs(qm1),coeffs(qm2))
+    QAT = similar_type(qm1, qm2)
+    return QAT(div, bases(qm1,1), bases(qm2,2))
+end
+
+# Matrix Division, A*X=B; X = \(A,B), where A is AbstractQuMatrix and B is AbstractQuVector
+function \{B<:OrthonormalBasis}(op::AbstractQuMatrix{B}, vec::AbstractQuVector{B})
+    div = \(coeffs(op), coeffs(vec))
+    QAT = similar_type(vec)
+    return QAT(div, bases(op,1))
+end
+
 # matrix operations returning a scalar
 # normalization
 Base.norm(qarr::AbstractQuArray) = vecnorm(rawcoeffs(qarr))

--- a/src/arrays/spinops.jl
+++ b/src/arrays/spinops.jl
@@ -11,9 +11,9 @@ HalfSpin{T}(val::T) = HalfSpin{T}(val)
 spin(s::HalfSpin) = s
 spin(j::Integer) = HalfSpin(2*j)
 function spin(j)
-    if isinteger(j)       
+    if isinteger(j)
         return spin(@compat(Int(j))) # j = 0.0, 1.0, 2.0...
-    elseif isinteger(2*j) 
+    elseif isinteger(2*j)
         return HalfSpin(@compat(Int(2*j))) # j = .5, 1.5, 2.5...
     else
         error("Spin must be a multiple of 1/2.")
@@ -68,11 +68,11 @@ spinjm(j) = QuArray(spinjm_mat(j))
 ############################
 #  Pauli spin 1/2 matrices #
 ############################
-const sigmax = 2.0 * spinjx(1/2)
-const sigmay = 2.0 * spinjy(1/2)
-const sigmaz = 2.0 * spinjz(1/2)
-const sigmap = sigmax + im * sigmay
-const sigmam = sigmax - im * sigmay
+const sigmax = 2.0 * full(spinjx(1/2))
+const sigmay = 2.0 * full(spinjy(1/2))
+const sigmaz = 2.0 * full(spinjz(1/2))
+const sigmap = full(sigmax) + im * full(sigmay)
+const sigmam = full(sigmax) - im * full(sigmay)
 
 # TODO : unicode sigmay, sigmaz
 const σₓ = sigmax

--- a/test/multest.jl
+++ b/test/multest.jl
@@ -31,3 +31,9 @@ qv = QuArray(v)
 
 # a simple test of the `==` operator
 @assert qm*3im == scale!(3im, copy(qm))
+
+# tests for Matrix Division
+v1 =  [0.5+0*im, 0.+0.*im]
+qv1 = normalize!(QuArray(v1))
+@assert coeffs(\(sigmax,qv1)) == [0.+0.*im, 1.+0.*im]
+@assert coeffs(\(sigmaz, sigmax)) == [0. 1.;-1. 0.]


### PR DESCRIPTION
From the #34 converting pauli to dense using full.
Matrix division support added for A*X == B where A & B are`AbstractQuMatrix` & `AbstractQuMatrix` and A & B are `AbstractQuMatrix` and `AbstarctQuMatrix`.
Tests added.
