### PR TITLE
Complex coeffs support.

### DIFF
--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -122,7 +122,7 @@ function \{B<:OrthonormalBasis}(op::AbstractQuMatrix{B}, vec::AbstractQuVector{B
 end
 
 # convert coeffs to complex
-Base.complex{B<:OrthonormalBasis}(qarr::AbstractQuArray{B}) = similar_type(qarr)(complex(coeffs(vec(qarr))), bases(qarr))
+Base.complex{B<:OrthonormalBasis}(qarr::AbstractQuArray{B}) = similar_type(qarr)(complex(coeffs(qarr)), bases(qarr))
 
 #  Vectorize QuArray
 Base.vec{B<:OrthonormalBasis}(vec1::AbstractQuArray{B}) = QuArray(vec(coeffs(vec1)))
@@ -201,8 +201,15 @@ tensor(bra::DualVector, ket::AbstractQuVector) = tensor(ket, bra)
 commute(a::AbstractQuMatrix, b::AbstractQuMatrix) = (a*b) - (b*a)
 anticommute(a::AbstractQuMatrix, b::AbstractQuMatrix) = (a*b) + (b*a)
 
+###############
+#  Expectaion #
+###############
+expectation(qarr::AbstractQuVector, op::AbstractQuMatrix) = vec(qarr)'*op*vec(qarr)
+expectation(qarr::AbstractQuMatrix, op::AbstractQuMatrix) = trace(qarr*op)
+
 export normalize,
     normalize!,
     tensor,
     commute,
-    anticommute
+    anticommute,
+    expectation

--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -121,6 +121,9 @@ function \{B<:OrthonormalBasis}(op::AbstractQuMatrix{B}, vec::AbstractQuVector{B
     return QAT(div, bases(op,1))
 end
 
+# convert coeffs to complex
+Base.complex{B<:OrthonormalBasis}(qarr::AbstractQuArray{B}) = similar_type(qarr)(complex(coeffs(vec(qarr))), bases(qarr))
+
 #  Vectorize QuArray
 Base.vec{B<:OrthonormalBasis}(vec1::AbstractQuArray{B}) = QuArray(vec(coeffs(vec1)))
 

--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -123,6 +123,8 @@ end
 
 # convert coeffs to complex
 Base.complex{B<:OrthonormalBasis}(qarr::AbstractQuArray{B}) = similar_type(qarr)(complex(coeffs(qarr)), bases(qarr))
+Base.float{B<:OrthonormalBasis}(qarr::AbstractQuArray{B}) = similar_type(qarr)(float(coeffs(qarr)), bases(qarr))
+Base.int{B<:OrthonormalBasis}(qarr::AbstractQuArray{B}) = similar_type(qarr)(int(coeffs(qarr)), bases(qarr))
 
 #  Vectorize QuArray
 Base.vec{B<:OrthonormalBasis}(vec1::AbstractQuArray{B}) = QuArray(vec(coeffs(vec1)))

--- a/test/multest.jl
+++ b/test/multest.jl
@@ -55,3 +55,6 @@ qv1 = normalize!(QuArray(v1))
 
 # Vectorize
 @assert vec(qv) == vec(qv')
+
+# Complex coeffs
+@assert complex(statevec(1, FiniteBasis(2))) == QuArray([1.+0.*im, 0.+0.*im])

--- a/test/multest.jl
+++ b/test/multest.jl
@@ -58,3 +58,5 @@ qv1 = normalize!(QuArray(v1))
 
 # Complex coeffs
 @assert complex(statevec(1, FiniteBasis(2))) == QuArray([1.+0.*im, 0.+0.*im])
+@assert float(statevec(1, FiniteBasis(2))) == QuArray([1., 0.])
+@assert int(statevec(1, FiniteBasis(2))) == QuArray([1, 0])


### PR DESCRIPTION
Currently we get an error doing this : 

``` julia
julia> statevec(1, FiniteBasis(2))
2-element QuVector in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,1}
[1.0,0.0]

julia> complex(statevec(1, FiniteBasis(2)))
ERROR: `complex` has no method matching complex(::QuArray{FiniteBasis{Orthonormal},Float64,1,Array{Float64,1}})
```

This further gives an error when we do something like this : 

``` julia
julia> using QuDynamics

julia> qode45 = QuPropagator(sigmax, statevec(1, FiniteBasis(2)), 0.:0.1:2*pi, QuODE45())
QuPropagator{QuODE45,QuArray{FiniteBasis{Orthonormal},Float64,1,Array{Float64,1}},QuSchrodingerEq{H<:AbstractQuArray{B<:AbstractBasis{S<:AbstractStructure},T,2}}}(QuSchrodingerEq{QuArray{FiniteBasis{Orthonormal},Float64,2,Array{Float64,2}}}(2x2 QuMatrix in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,2}
[0.0 1.0
 1.0 0.0]),2-element QuVector in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,1}
[1.0,0.0],0.0:0.1:6.2,QuODE45(Dict{Symbol,Any}()))

julia> next_qode45 = next(qode45, start(qode45))
ERROR: InexactError()
 in setindex! at array.jl:307
 in copy! at abstractarray.jl:149
 in setindex! at array.jl:307
 in oderk_adapt at .julia/v0.3/ODE/src/runge_kutta.jl:279
 in ode45_dp at .julia/v0.3/ODE/src/runge_kutta.jl:212
 in propagate at .julia/v0.3/QuDynamics/src/propodesolvers.jl:28
 in next at .julia/v0.3/QuDynamics/src/propmachinery.jl:47
```

This PR aims to fix this.
