### PR TITLE
Multiplication fix.

### DIFF
--- a/src/arrays/arraymath.jl
+++ b/src/arrays/arraymath.jl
@@ -55,7 +55,7 @@ function *{B<:OrthonormalBasis}(dm::DualMatrix{B}, qm::AbstractQuMatrix{B})
 end
 
 function *{B<:OrthonormalBasis}(qm::AbstractQuMatrix{B}, dm::DualMatrix{B})
-    mc = A_mul_Bc(rawcoeffs(dm), rawcoeffs(qm))
+    mc = A_mul_Bc(rawcoeffs(qm), rawcoeffs(dm))
     QAT = similar_type(qm)
     return QAT(mc, bases(qm,1), bases(dm,2))
 end

--- a/test/multest.jl
+++ b/test/multest.jl
@@ -7,27 +7,29 @@ v = [1.0,2.0,3.0]
 qm = QuArray(m)
 qv = QuArray(v)
 
-@assert rawcoeffs(qm*qm) == m*m
+@assert coeffs(qm*qm) == m*m
+@assert coeffs(qm'*qm) == m'*m
+@assert coeffs(qm*qm') == m*m'
+@assert coeffs(qm'*qm') == m'*m'
 @assert rawcoeffs(qm'*qm') == m*m
-@assert rawcoeffs(qm'*qm) == m'*m
-@assert rawcoeffs(qm*qm') == m*m'
 
-@assert rawcoeffs(qm*qv) == m*v
+@assert coeffs(qm*qv) == m*v
 @assert rawcoeffs(qv'*qm') == m*v
-@assert rawcoeffs(qm'*qv) == m'*v
-@assert rawcoeffs(qv'*qm) == m'*v
+@assert coeffs(qv'*qm') == v'*m'
+@assert coeffs(qm'*qv) == m'*v
+@assert coeffs(qv'*qm) == v'*m
 
 @assert qv'*qv == dot(v,v)
-@assert rawcoeffs(qv*qv') == v*v'
+@assert coeffs(qv*qv') == v*v'
 
 @assert qv'*qm*qv == first(v'*m*v)
 
-@assert rawcoeffs(2*im*qv) == 2*im*v
-@assert rawcoeffs(qv/2) == v/2
-@assert rawcoeffs(scale(2,qv)) == 2*v
+@assert coeffs(2*im*qv) == 2*im*v
+@assert coeffs(qv/2) == v/2
+@assert coeffs(scale(2,qv)) == 2*v
 @assert coeffs(qm' * -im) == -im * m'
 @assert norm(qv) == norm(v)
-@test_approx_eq rawcoeffs(normalize(qv)) rawcoeffs(qv)/norm(v)
+@test_approx_eq coeffs(normalize(qv)) coeffs(qv)/norm(v)
 
 # a simple test of the `==` operator
 @assert qm*3im == scale!(3im, copy(qm))


### PR DESCRIPTION
The following case fails 

``` julia
julia> a = full(tensor(lowerop(2), QuArray(eye(2))))
4x4 QuMatrix in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,2}
[0.0 0.0 1.0 0.0
 0.0 0.0 0.0 1.0
 0.0 0.0 0.0 0.0
 0.0 0.0 0.0 0.0]

julia> sm = full(tensor(QuArray(eye(2)), lowerop(2)))
4x4 QuMatrix in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,2}
[0.0 1.0 0.0 0.0
 0.0 0.0 0.0 0.0
 0.0 0.0 0.0 1.0
 0.0 0.0 0.0 0.0]

julia> a*sm'
4x4 QuMatrix in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,2}
[0.0 0.0 0.0 0.0
 0.0 0.0 0.0 0.0
 0.0 1.0 0.0 0.0
 0.0 0.0 0.0 0.0]
```

the last one has to be 

``` julia
julia> a*sm'
4x4 QuMatrix in FiniteBasis{Orthonormal}:
...coefficients: Array{Float64,2}
[0.0 0.0 0.0 0.0
 0.0 0.0 1.0 0.0
 0.0 0.0 0.0 0.0
 0.0 0.0 0.0 0.0]
```
